### PR TITLE
Fixed another example to conform to new basicSampling output

### DIFF
--- a/examples/FEniCS/BET_script.py
+++ b/examples/FEniCS/BET_script.py
@@ -18,7 +18,6 @@ to the number of KL terms) and the number of samples in this space.
 """
 
 import numpy as np
-import bet.calculateP as calculateP
 import bet.postProcess as postProcess
 import bet.calculateP.simpleFunP as simpleFunP
 import bet.calculateP.calculateP as calculateP
@@ -59,9 +58,9 @@ per dimension.
 # Generate samples on the parameter space
 randomSampling = False
 if randomSampling is True:
-    sampler.random_sample_set('random', input_samples, num_samples=1E4)
+    input_samples = sampler.random_sample_set('random', input_samples, num_samples=1E4)
 else:
-    sampler.regular_sample_set(input_samples, num_samples_per_dim=[50, 50])
+    input_samples = sampler.regular_sample_set(input_samples, num_samples_per_dim=[50, 50])
 
 '''
 Suggested changes for user:

--- a/examples/linearMap/linearMapUniformSampling.py
+++ b/examples/linearMap/linearMapUniformSampling.py
@@ -26,7 +26,6 @@ the random discretizations.
 """
 
 import numpy as np
-import bet.calculateP as calculateP
 import bet.postProcess as postProcess
 import bet.calculateP.simpleFunP as simpleFunP
 import bet.calculateP.calculateP as calculateP

--- a/examples/nonlinearMap/nonlinearMapUniformSampling.py
+++ b/examples/nonlinearMap/nonlinearMapUniformSampling.py
@@ -25,7 +25,6 @@ in the parameter space are calculated using emulated points.
 
 
 import numpy as np
-import bet.calculateP as calculateP
 import bet.postProcess as postProcess
 import bet.calculateP.simpleFunP as simpleFunP
 import bet.calculateP.calculateP as calculateP

--- a/examples/validationExample/linearMap.py
+++ b/examples/validationExample/linearMap.py
@@ -10,7 +10,6 @@ used to define the output probability measure.
 
 from bet.Comm import comm, MPI
 import numpy as np
-import bet.calculateP as calculateP
 import bet.postProcess as postProcess
 import bet.calculateP.simpleFunP as simpleFunP
 import bet.calculateP.calculateP as calculateP
@@ -47,9 +46,9 @@ per dimension.
 # Generate samples on the parameter space
 randomSampling = False
 if randomSampling is True:
-    sampler.random_sample_set('random', input_samples, num_samples=1E3)
+    input_samples = sampler.random_sample_set('random', input_samples, num_samples=1E3)
 else:
-    sampler.regular_sample_set(input_samples, num_samples_per_dim=[30, 30])
+    input_samples = sampler.regular_sample_set(input_samples, num_samples_per_dim=[30, 30])
 
 '''
 Suggested changes for user:


### PR DESCRIPTION
I probably should have checked more files than just those in the linear/ and nonlinear/ folders before merge request #223 and just done this along with that one, but I have found the same error brought up in issue #222 (files were using the old output format of basicSampling in two other files: 
validationExample/linearMap.py
FEniCS/BET_script.py

I have fixed them and this is the primary contribution to this pull request. 

Furthermore, in addition to this, I have also deleted from the above two files (plus the linear/nonlinear uniform sampling examples in the aforementioned issue), the redundant loading of the ```calculateP``` module, which was being loaded twice. I checked around other examples and I believe caught all such redundancies.