### PR TITLE
Regular sampling now defines uniform cells

### DIFF
--- a/bet/sample.py
+++ b/bet/sample.py
@@ -1179,9 +1179,9 @@ class rectangle_sample_set(sample_set_base):
         Initialization
 
         :param maxes: array or list of maxes for hyperrectangles
-        :type maxes: interable with components of length dim
+        :type maxes: iterable with components of length dim
         :param mins: array or list of mins for hyperrectangles
-        :type mins: interable with components of length dim
+        :type mins: iterable with components of length dim
 
         """
         # Check dimensions
@@ -1349,7 +1349,7 @@ class ball_sample_set(sample_set_base):
         Initialize.
         
         :param centers: centers of balls
-        :type centers: interable of shape (num-1, dim)
+        :type centers: iterable of shape (num-1, dim)
         :param radii: radii of balls
         :type radii: iterable of length num-1
         

--- a/bet/sampling/basicSampling.py
+++ b/bet/sampling/basicSampling.py
@@ -173,7 +173,7 @@ def regular_sample_set(input_obj, num_samples_per_dim=1):
     vec_samples_dimension = np.empty((dim), dtype=object)
     for i in np.arange(0, dim):
         bin_width = (input_domain[i, 1] - input_domain[i, 0]) / \
-                    num_samples_per_dim[i]
+                    np.float(num_samples_per_dim[i])
         vec_samples_dimension[i] = list(np.linspace(
             input_domain[i, 0] - 0.5 * bin_width,
             input_domain[i, 1] + 0.5 * bin_width,

--- a/bet/sampling/basicSampling.py
+++ b/bet/sampling/basicSampling.py
@@ -172,9 +172,12 @@ def regular_sample_set(input_obj, num_samples_per_dim=1):
 
     vec_samples_dimension = np.empty((dim), dtype=object)
     for i in np.arange(0, dim):
+        bin_width = (input_domain[i, 1] - input_domain[i, 0]) / \
+                    num_samples_per_dim[i]
         vec_samples_dimension[i] = list(np.linspace(
-            input_domain[i, 0], input_domain[i, 1],
-            num_samples_per_dim[i]+2))[1:num_samples_per_dim[i]+1]
+            input_domain[i, 0] - 0.5 * bin_width,
+            input_domain[i, 1] + 0.5 * bin_width,
+            num_samples_per_dim[i] + 2))[1:num_samples_per_dim[i] + 1]
 
     if np.equal(dim, 1):
         arrays_samples_dimension = np.array([vec_samples_dimension])

--- a/test/test_sampling/test_basicSampling.py
+++ b/test/test_sampling/test_basicSampling.py
@@ -381,8 +381,11 @@ def verify_regular_sample_set(sampler, input_sample_set,
 
     vec_samples_dimension = np.empty((dim), dtype=object)
     for i in np.arange(0, dim):
+        bin_width = (test_domain[i, 1] - test_domain[i, 0]) / \
+                    np.float(num_samples_per_dim[i])
         vec_samples_dimension[i] = list(np.linspace(
-            test_domain[i, 0], test_domain[i, 1],
+            test_domain[i, 0] - 0.5 * bin_width,
+            test_domain[i, 1] + 0.5 * bin_width,
             num_samples_per_dim[i] + 2))[1:num_samples_per_dim[i] + 1]
 
     if np.equal(dim, 1):
@@ -432,8 +435,11 @@ def verify_regular_sample_set_domain(sampler, input_domain,
 
     vec_samples_dimension = np.empty((dim), dtype=object)
     for i in np.arange(0, dim):
+        bin_width = (test_domain[i, 1] - test_domain[i, 0]) / \
+                    np.float(num_samples_per_dim[i])
         vec_samples_dimension[i] = list(np.linspace(
-            test_domain[i, 0], test_domain[i, 1],
+            test_domain[i, 0] - 0.5 * bin_width,
+            test_domain[i, 1] + 0.5 * bin_width,
             num_samples_per_dim[i] + 2))[1:num_samples_per_dim[i] + 1]
 
     if np.equal(dim, 1):
@@ -484,8 +490,11 @@ def verify_regular_sample_set_dimension(sampler, input_dim,
 
     vec_samples_dimension = np.empty((dim), dtype=object)
     for i in np.arange(0, dim):
+        bin_width = (test_domain[i, 1] - test_domain[i, 0]) / \
+                    np.float(num_samples_per_dim[i])
         vec_samples_dimension[i] = list(np.linspace(
-            test_domain[i, 0], test_domain[i, 1],
+            test_domain[i, 0] - 0.5 * bin_width,
+            test_domain[i, 1] + 0.5 * bin_width,
             num_samples_per_dim[i] + 2))[1:num_samples_per_dim[i] + 1]
 
     if np.equal(dim, 1):


### PR DESCRIPTION
Before it took an interior grid of points from a regular grid of samples that included the boundary. The points are still interior, but now the implicitly defined grid is of uniformly sized rectangles, which is more likely what a user would want anyway. 