### PR TITLE
better parallelize random sampling

### DIFF
--- a/bet/sample.py
+++ b/bet/sample.py
@@ -344,6 +344,43 @@ class sample_set_base(object):
                                                   first_array)) 
         if self._values is not None and self._values.shape[1] != self._dim:
             raise dim_not_matching("dimension of values incorrect")
+            
+        if num is None:
+            num_local = self.check_num_local()
+            if num_local is None:
+                num_local = 0
+            num = comm.allreduce(num_local, op=MPI.SUM)
+        
+        return num
+
+    def check_num_local(self):
+        """
+        
+        Checks that the number of entries in ``self._values_local``,
+        ``self._volumes_local``, ``self._probabilities_local``, 
+        ``self._jacobians_local``, and ``self._error_estimates_local`` 
+        all match (assuming the named array exists).
+        
+        :rtype: int
+        :returns: num
+
+        """
+        num = None
+        for array_name in self.array_names:
+            array_name_local = array_name + "_local"
+            current_array = getattr(self, array_name_local)
+            if current_array is not None:
+                if num is None:
+                    num = current_array.shape[0]
+                    first_array = array_name
+                else:
+                    if num != current_array.shape[0]:
+                        errortxt = "length of {} inconsistent with {}"
+                        raise length_not_matching(errortxt.format(array_name,
+                                                  first_array)) 
+        if self._values is not None and self._values.shape[1] != self._dim:
+            raise dim_not_matching("dimension of values incorrect")
+            
         return num
 
     def get_dim(self):

--- a/bet/sampling/basicSampling.py
+++ b/bet/sampling/basicSampling.py
@@ -123,21 +123,27 @@ def random_sample_set(sample_type, input_obj, num_samples,
         # create the domain
         input_domain = np.array([[0., 1.]]*dim)
         input_sample_set.set_domain(input_domain)
-    # update the bounds based on the number of samples
-    input_sample_set.update_bounds(num_samples)
-    input_values = np.copy(input_sample_set._width)
      
     if sample_type == "lhs":
-        input_values = input_values * lhs(dim,
+        # update the bounds based on the number of samples
+         input_sample_set.update_bounds(num_samples)
+         input_values = np.copy(input_sample_set._width)
+         input_values = input_values * lhs(dim,
                 num_samples, criterion)
-    elif sample_type == "random" or "r":
-        if comm.rank == 0:
-            input_values = input_values * np.random.random(input_values.shape)
-        input_values = comm.bcast(input_values)
-    input_values = input_values + input_sample_set._left
-    
-    input_sample_set.set_values_local(np.array_split(input_values,
+         input_values = input_values + input_sample_set._left
+         input_sample_set.set_values_local(np.array_split(input_values,
         comm.size)[comm.rank])
+    elif sample_type == "random" or "r":
+        # define local number of samples
+        num_samples_local =  int((num_samples/comm.size) + \
+            (comm.rank < num_samples%comm.size))
+        # update the bounds based on the number of samples
+        input_sample_set.update_bounds_local(num_samples_local)
+        input_values_local = np.copy(input_sample_set._width_local)
+        input_values_local = input_values_local * np.random.random(input_values_local.shape)
+        input_values_local = input_values_local + input_sample_set._left_local
+    
+        input_sample_set.set_values_local(input_values_local)
     comm.barrier()
 
     if globalize:

--- a/bet/sampling/basicSampling.py
+++ b/bet/sampling/basicSampling.py
@@ -144,6 +144,7 @@ def random_sample_set(sample_type, input_obj, num_samples,
         input_values_local = input_values_local + input_sample_set._left_local
     
         input_sample_set.set_values_local(input_values_local)
+    
     comm.barrier()
 
     if globalize:

--- a/test/test_sampling/test_basicSampling.py
+++ b/test/test_sampling/test_basicSampling.py
@@ -171,11 +171,12 @@ def verify_create_random_discretization(model, sampler, sample_type, input_domai
     assert np.all(my_discretization._input_sample_set._values <= input_right)
     assert np.all(my_discretization._input_sample_set._values >= input_left)
 
-    # compare the samples
-    nptest.assert_array_equal(input_sample_set._values,
+    if comm.size == 0:
+        # compare the samples
+        nptest.assert_array_equal(input_sample_set._values,
             my_discretization._input_sample_set._values)
-    # compare the data
-    nptest.assert_array_equal(output_sample_set._values,
+        # compare the data
+        nptest.assert_array_equal(output_sample_set._values,
             my_discretization._output_sample_set._values)
 
     # did num_samples get updated?
@@ -207,11 +208,12 @@ def verify_create_random_discretization(model, sampler, sample_type, input_domai
     assert np.all(my_discretization._input_sample_set._values <= input_right)
     assert np.all(my_discretization._input_sample_set._values >= input_left)
 
-    # compare the samples
-    nptest.assert_array_equal(input_sample_set._values,
+    if comm.size == 0:
+        # compare the samples
+        nptest.assert_array_equal(input_sample_set._values,
                               my_discretization._input_sample_set._values)
-    # compare the data
-    nptest.assert_array_equal(output_sample_set._values,
+        # compare the data
+        nptest.assert_array_equal(output_sample_set._values,
                               my_discretization._output_sample_set._values)
 
     # reset the random seed
@@ -249,11 +251,12 @@ def verify_create_random_discretization(model, sampler, sample_type, input_domai
     assert np.all(my_discretization._input_sample_set._values <= input_right)
     assert np.all(my_discretization._input_sample_set._values >= input_left)
 
-    # compare the samples
-    nptest.assert_array_equal(input_sample_set._values,
+    if comm.size == 0:
+        # compare the samples
+        nptest.assert_array_equal(input_sample_set._values,
                               my_discretization._input_sample_set._values)
-    # compare the data
-    nptest.assert_array_equal(output_sample_set._values,
+        # compare the data
+        nptest.assert_array_equal(output_sample_set._values,
                               my_discretization._output_sample_set._values)
 
 
@@ -292,7 +295,8 @@ def verify_random_sample_set_domain(sampler, sample_type, input_domain,
     assert np.all(my_sample_set._values >= input_left)
 
     # compare the samples
-    nptest.assert_array_equal(input_sample_set._values,
+    if comm.size == 0:
+        nptest.assert_array_equal(input_sample_set._values,
                               my_sample_set._values)
 
 def verify_random_sample_set_dimension(sampler, sample_type, input_dim,
@@ -331,7 +335,8 @@ def verify_random_sample_set_dimension(sampler, sample_type, input_dim,
     assert np.all(my_sample_set._values >= input_left)
 
     # compare the samples
-    nptest.assert_array_equal(input_sample_set._values,
+    if comm.size == 0:
+        nptest.assert_array_equal(input_sample_set._values,
                               my_sample_set._values)
 
 def verify_random_sample_set(sampler, sample_type, input_sample_set,
@@ -371,7 +376,8 @@ def verify_random_sample_set(sampler, sample_type, input_sample_set,
     assert np.all(my_sample_set._values >= input_left)
 
     # compare the samples
-    nptest.assert_array_equal(test_sample_set._values,
+    if comm.size == 0:
+        nptest.assert_array_equal(test_sample_set._values,
                               my_sample_set._values)
 
 def verify_regular_sample_set(sampler, input_sample_set,


### PR DESCRIPTION
Generates random samples locally, rather than globally, slicing the array, and defining them locally. This will be especially useful when making extremely large emulated sets running in parallel, where the global array might be large enough to cause memory issues. 