### PR TITLE
Solving 1-D Cartesian sample set issue and examples calling old plot command style

### DIFF
--- a/bet/sample.py
+++ b/bet/sample.py
@@ -2044,8 +2044,8 @@ class cartesian_sample_set(rectangle_sample_set):
             xmin.append(xv[0:-1])
             xmax.append(xv[1::])
         if len(xmax) == 1:
-            maxes = np.array([xmax])
-            mins = np.array([xmin])
+            maxes = np.transpose(np.array([xmax]))
+            mins = np.transpose(np.array([xmin]))
         else:
             maxes = np.vstack(np.array(np.meshgrid(*xmax)).T)
             mins = np.vstack(np.array(np.meshgrid(*xmin)).T)

--- a/examples/FEniCS/BET_script.py
+++ b/examples/FEniCS/BET_script.py
@@ -98,10 +98,11 @@ Q_ref = my_model(param_ref)
 
 # Create some plots of input and output discretizations
 plotD.scatter_2D(input_samples, ref_sample=param_ref[0,:],
-                 filename='FEniCS_ParameterSamples.eps')
+                 filename='FEniCS_ParameterSamples',
+                 file_extension = '.eps')
 if Q_ref.size == 2:
     plotD.show_data_domain_2D(my_discretization, Q_ref=Q_ref[0,:],
-            file_extension="eps")
+            file_extension=".eps")
 
 '''
 Suggested changes for user:
@@ -133,8 +134,10 @@ calculateP.prob(my_discretization)
 marginals2D = plotP.smooth_marginals_2D(marginals2D, bins, sigma=0.5)
 
 # plot 2d marginals probs
-plotP.plot_2D_marginal_probs(marginals2D, bins, input_samples, filename="FEniCS",
-                             lam_ref=param_ref[0,:], file_extension=".eps",
+plotP.plot_2D_marginal_probs(marginals2D, bins, input_samples,
+                             filename="FEniCS",
+                             lam_ref=param_ref[0,:],
+                             file_extension=".eps",
                              plot_surface=False)
 
 # calculate 1d marginal probs
@@ -143,8 +146,10 @@ plotP.plot_2D_marginal_probs(marginals2D, bins, input_samples, filename="FEniCS"
 # smooth 1d marginal probs (optional)
 marginals1D = plotP.smooth_marginals_1D(marginals1D, bins, sigma=0.5)
 # plot 2d marginal probs
-plotP.plot_1D_marginal_probs(marginals1D, bins, input_samples, filename="FEniCS",
-                             lam_ref=param_ref[0,:], file_extension=".eps")
+plotP.plot_1D_marginal_probs(marginals1D, bins, input_samples,
+                             filename="FEniCS",
+                             lam_ref=param_ref[0,:],
+                             file_extension=".eps")
 
 
 

--- a/examples/linearMap/linearMapUniformSampling.py
+++ b/examples/linearMap/linearMapUniformSampling.py
@@ -104,8 +104,9 @@ Q_ref =  my_model(param_ref)
 
 # Create some plots of input and output discretizations
 plotD.scatter_2D_multi(input_samples, ref_sample= param_ref, showdim = 'all',
-                       filename = 'linearMap_ParameterSamples.eps')
-plotD.show_data_domain_2D(my_discretization, Q_ref = Q_ref, file_extension='eps')
+                       filename = 'linearMap_ParameterSamples',
+                       file_extension = '.eps')
+plotD.show_data_domain_2D(my_discretization, Q_ref = Q_ref, file_extension='.eps')
 
 '''
 Suggested changes for user:

--- a/examples/linearMap/myModel.py
+++ b/examples/linearMap/myModel.py
@@ -6,5 +6,6 @@ import numpy as np
 # Define a model that is a linear QoI map
 def my_model(parameter_samples):
     Q_map = np.array([[0.506, 0.463],[0.253, 0.918], [0.085, 0.496]])
+    #Q_map = np.array([[0.506], [0.253], [0.085]])
     QoI_samples = np.dot(parameter_samples,Q_map)
     return QoI_samples

--- a/examples/nonlinearMap/nonlinearMapUniformSampling.py
+++ b/examples/nonlinearMap/nonlinearMapUniformSampling.py
@@ -106,9 +106,10 @@ Q_ref =  my_model(param_ref)
 
 # Create some plots of input and output discretizations
 plotD.scatter_2D(input_samples, ref_sample = param_ref,
-                 filename = 'nonlinearMapParameterSamples.eps')
+                 filename = 'nonlinearMapParameterSamples',
+                 file_extension='.eps')
 if Q_ref.size == 2:
-    plotD.show_data_domain_2D(my_discretization, Q_ref = Q_ref, file_extension="eps")
+    plotD.show_data_domain_2D(my_discretization, Q_ref = Q_ref, file_extension=".eps")
 
 '''
 Suggested changes for user:

--- a/examples/validationExample/linearMap.py
+++ b/examples/validationExample/linearMap.py
@@ -124,9 +124,15 @@ calculateP.prob(my_discretization)
 # Post-process the results (optional)
 ########################################
 # Show some plots of the different sample sets
-plotD.scatter_2D(my_discretization._input_sample_set, filename = 'Parameter_Samples.eps')
-plotD.scatter_2D(my_discretization._output_sample_set, filename = 'QoI_Samples.eps')
-plotD.scatter_2D(my_discretization._output_probability_set, filename = 'Data_Space_Discretization.eps')
+plotD.scatter_2D(my_discretization._input_sample_set,
+                 filename = 'Parameter_Samples',
+                 file_extension = '.eps')
+plotD.scatter_2D(my_discretization._output_sample_set,
+                 filename = 'QoI_Samples',
+                 file_extension = '.eps')
+plotD.scatter_2D(my_discretization._output_probability_set,
+                 filename = 'Data_Space_Discretization',
+                 file_extension = '.eps')
 '''
 Suggested changes for user:
 
@@ -146,14 +152,16 @@ the structure of a high dimensional non-parametric probability measure.
                                                         nbins = [30, 30])
 
 # plot 2d marginals probs
-plotP.plot_2D_marginal_probs(marginals2D, bins, input_samples, filename = "validation_raw",
+plotP.plot_2D_marginal_probs(marginals2D, bins, input_samples,
+                             filename = "validation_raw",
                              file_extension = ".eps", plot_surface=False)
 
 # smooth 2d marginals probs (optional)
 marginals2D = plotP.smooth_marginals_2D(marginals2D, bins, sigma=0.1)
 
 # plot 2d marginals probs
-plotP.plot_2D_marginal_probs(marginals2D, bins, input_samples, filename = "validation_smooth",
+plotP.plot_2D_marginal_probs(marginals2D, bins, input_samples,
+                             filename = "validation_smooth",
                              file_extension = ".eps", plot_surface=False)
 
 # calculate 1d marginal probs
@@ -161,14 +169,16 @@ plotP.plot_2D_marginal_probs(marginals2D, bins, input_samples, filename = "valid
                                                         nbins = [30, 30])
 
 # plot 2d marginal probs
-plotP.plot_1D_marginal_probs(marginals1D, bins, input_samples, filename = "validation_raw",
+plotP.plot_1D_marginal_probs(marginals1D, bins, input_samples,
+                             filename = "validation_raw",
                              file_extension = ".eps")
 
 # smooth 1d marginal probs (optional)
 marginals1D = plotP.smooth_marginals_1D(marginals1D, bins, sigma=0.1)
 
 # plot 2d marginal probs
-plotP.plot_1D_marginal_probs(marginals1D, bins, input_samples, filename = "validation_smooth",
+plotP.plot_1D_marginal_probs(marginals1D, bins, input_samples,
+                             filename = "validation_smooth",
                              file_extension = ".eps")
 
 


### PR DESCRIPTION
Now the 1-D Cartesian sample set works.

Fixed examples where filenames contained file_extensions, which was causing an error. 