### PR TITLE
Minor typos in validation example and nonlinear example fixed

### DIFF
--- a/doc/examples/example_rst_files/nonlinearMapUniformSampling.rst
+++ b/doc/examples/example_rst_files/nonlinearMapUniformSampling.rst
@@ -25,7 +25,7 @@ solution to the elliptic PDE
 where 
 
 .. math:: A(\lambda)=\left(\begin{array}{cc}
-		1/\lambda_1 & 0 \\ 0 & 1/\lambda_2 \end{array}\right),
+		1/\lambda_1^2 & 0 \\ 0 & 1/\lambda_2^2 \end{array}\right),
 .. math:: f(x,y;\lambda) = \pi^2 \sin(\pi x\lambda_1)\sin(\pi y \lambda_2),
 and 
 

--- a/examples/linearMap/linearMapUniformSampling.py
+++ b/examples/linearMap/linearMapUniformSampling.py
@@ -118,7 +118,7 @@ size is determined by scaling the circumscribing box of D.
 randomDataDiscretization = False
 if randomDataDiscretization is False:
     simpleFunP.regular_partition_uniform_distribution_rectangle_scaled(
-        data_set=my_discretization, Q_ref=Q_ref, rect_scale=0.15,
+        data_set=my_discretization, Q_ref=Q_ref, rect_scale=0.25,
         cells_per_dimension = 3)
 else:
     simpleFunP.uniform_partition_uniform_distribution_rectangle_scaled(

--- a/examples/linearMap/linearMapUniformSampling.py
+++ b/examples/linearMap/linearMapUniformSampling.py
@@ -118,7 +118,7 @@ size is determined by scaling the circumscribing box of D.
 randomDataDiscretization = False
 if randomDataDiscretization is False:
     simpleFunP.regular_partition_uniform_distribution_rectangle_scaled(
-        data_set=my_discretization, Q_ref=Q_ref, rect_scale=0.25,
+        data_set=my_discretization, Q_ref=Q_ref, rect_scale=0.15,
         cells_per_dimension = 3)
 else:
     simpleFunP.uniform_partition_uniform_distribution_rectangle_scaled(

--- a/examples/nonlinearMap/myModel.py
+++ b/examples/nonlinearMap/myModel.py
@@ -34,7 +34,7 @@ if QoI_num == 1:
 else:
     x1 = 0.5
     y1 = 0.15
-    x2 = 0.15
+    x2 = 0.1
     y2 = 0.25
     x = np.array([x1, x2])
     y = np.array([y1, y2])

--- a/examples/nonlinearMap/myModel.py
+++ b/examples/nonlinearMap/myModel.py
@@ -34,7 +34,7 @@ if QoI_num == 1:
 else:
     x1 = 0.5
     y1 = 0.15
-    x2 = 0.1
+    x2 = 0.15
     y2 = 0.25
     x = np.array([x1, x2])
     y = np.array([y1, y2])

--- a/examples/nonlinearMap/nonlinearMapUniformSampling.py
+++ b/examples/nonlinearMap/nonlinearMapUniformSampling.py
@@ -14,7 +14,7 @@ observations of the solution to the elliptic PDE .. math::
     u|_{\partial \Omega} &= 0,
   \end{cases}
 
-where :math:`A(\lambda)=\text{diag}(1/\lambda_1,1/\lambda_2)`,
+where :math:`A(\lambda)=\text{diag}(1/\lambda_1^2,1/\lambda_2^2)`,
 :math: `f(x,y;\lambda) = \pi^2 \sin(\pi x\lambda_1)\sin(\pi y \lambda_2)`,
 and :math:`\Omega=[0,1]\times[0,1]`.
 

--- a/examples/validationExample/myModel.py
+++ b/examples/validationExample/myModel.py
@@ -6,6 +6,6 @@ import numpy as np
 # Define a model that is a linear QoI map
 def my_model(parameter_samples):
     Q_map = np.array([[0.506, 0.463], [0.253, 0.918]])
-    QoI_samples = data= np.dot(parameter_samples,Q_map)
+    QoI_samples = np.dot(parameter_samples,Q_map)
     return QoI_samples
 


### PR DESCRIPTION
Diffusion parameters should be squares of lam1 and lam2 in the nonlinear example. Fixed now.

There was an extraneous `data` in the `myModel.py` of the validation example that is now gone. Pilosov had caught some of these in other examples. 