### PR TITLE
added tight_layout option

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -33,6 +33,7 @@ notifications:
             - steve.a.mattis@gmail.com
             - lichgraham@gmail.com
             - scottw13@gmail.com
+            - michael.pilosov@ucdenver.edu
         on_success: change
         on_failure: always
 # whitelist

--- a/README.md
+++ b/README.md
@@ -27,11 +27,11 @@ Tests
 
 To run tests in serial call::
 
-    nosetests tests
+    nosetests
 
 To run tests in parallel call::
 
-    mpirun -np NPROC nosetets tests
+    mpirun -np NPROC nosetests
 
 Dependencies
 ------------

--- a/bet/postProcess/plotP.py
+++ b/bet/postProcess/plotP.py
@@ -221,6 +221,7 @@ def plot_1D_marginal_probs(marginals, bins, sample_set,
                 label1 = lambda_label[i]
             ax.set_xlabel(label1) 
             ax.set_ylabel(r'$\rho$')
+            plt.tight_layout()
             fig.savefig(filename + "_1D_" + str(i) + file_extension,
                     transparent=True) 
             if interactive:
@@ -309,6 +310,7 @@ def plot_2D_marginal_probs(marginals, bins, sample_set,
             cb.set_label(label_cbar, size=20)
             plt.axis([lam_domain[i][0], lam_domain[i][1], lam_domain[j][0],
                 lam_domain[j][1]]) 
+            plt.tight_layout()
             fig.savefig(filename + "_2D_" + str(i) + "_" + str(j) +\
                     file_extension, transparent=True)
             if interactive:

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -383,7 +383,7 @@ class Test_sample_set(unittest.TestCase):
         jac = np.ones((self.num, 3, self.dim))
         self.sam_set.set_jacobians(jac)
         self.sam_set.global_to_local()
-        self.assertNotEqual(self.sam_set._values_local, None)
+        self.assertNotIn(None,self.sam_set._values_local)
         if comm.size > 1:
             for array_name in sample.sample_set.array_names:
                 current_array = getattr(self.sam_set, array_name+"_local")


### PR DESCRIPTION
The plt.tight_layout() command has been added to the marginals plotting code to fix an issue where axis labels are cut off on some matplotlib backends. This crops the layout of eps figures to include all components and minimize excessive whitespace. 