### PR TITLE
Fixed 1D regular sampling + tests and updates to FEniCS example

### DIFF
--- a/bet/postProcess/plotP.py
+++ b/bet/postProcess/plotP.py
@@ -221,8 +221,6 @@ def plot_1D_marginal_probs(marginals, bins, sample_set,
                 label1 = r'$\lambda_{' + str(i+1) + '}$'
             else:
                 label1 = lambda_label[i]
-            #ax.set_xlabel(label1) 
-            #ax.set_ylabel(r'$\rho$')
             ax.set_xlabel(label1, fontsize=30) 
             ax.set_ylabel(r'PDF', fontsize=30)
             ax.tick_params(axis='both', which='major', 
@@ -538,11 +536,6 @@ def plot_2D_marginal_contours(marginals, bins, sample_set,
             plt.clabel(quadmesh, fontsize=contour_font_size, 
                        inline=1, style='sci')
             
-#            label_cbar = r'$\rho_{\lambda_{' + str(i+1) + '}, ' 
-#            label_cbar += r'\lambda_{' + str(j+1) + '}' + '}$ (Lebesgue)'
-#            cb = fig.colorbar(quadmesh, ax=ax, label=label_cbar)
-#            cb.ax.tick_params(labelsize=14)
-#            cb.set_label(label_cbar, size=20)
             if plot_domain is None:
                 plt.axis([lam_domain[i][0], lam_domain[i][1], 
                           lam_domain[j][0], lam_domain[j][1]]) 
@@ -557,3 +550,4 @@ def plot_2D_marginal_contours(marginals, bins, sample_set,
                 plt.close()
  
     comm.barrier()
+    

--- a/bet/postProcess/plotP.py
+++ b/bet/postProcess/plotP.py
@@ -214,14 +214,19 @@ def plot_1D_marginal_probs(marginals, bins, sample_set,
             ax.plot(x_range, marginals[i]/(bins[i][1]-bins[i][0]))
             ax.set_ylim([0, 1.05*np.max(marginals[i]/(bins[i][1]-bins[i][0]))])
             if lam_ref is not None:
-                ax.plot(lam_ref[i], 0.0, 'ko', markersize=10)
+                ax.plot(lam_ref[i], 
+                        0.02*1.05*np.max(marginals[i]/(bins[i][1]-bins[i][0])),
+                        'ko', markersize=15)
             if lambda_label is None:
                 label1 = r'$\lambda_{' + str(i+1) + '}$'
             else:
                 label1 = lambda_label[i]
-            ax.set_xlabel(label1) 
-            ax.set_ylabel(r'$\rho$')
-            plt.tight_layout()
+            #ax.set_xlabel(label1) 
+            #ax.set_ylabel(r'$\rho$')
+            ax.set_xlabel(label1, fontsize=30) 
+            ax.set_ylabel(r'PDF', fontsize=30)
+            ax.tick_params(axis='both', which='major', 
+                           labelsize=20)
             fig.savefig(filename + "_1D_" + str(i) + file_extension,
                     transparent=True) 
             if interactive:
@@ -291,7 +296,8 @@ def plot_2D_marginal_probs(marginals, bins, sample_set,
                     interpolation='bicubic', cmap=cm.CMRmap_r, 
                     extent=[lam_domain[i][0], lam_domain[i][1],
                     lam_domain[j][0], lam_domain[j][1]], origin='lower',
-                    vmax=marginals[(i, j)].max()/boxSize, vmin=0, aspect='auto')
+                    vmax=marginals[(i, j)].max()/boxSize, vmin=0, 
+                    aspect='auto')
             if lam_ref is not None:
                 ax.plot(lam_ref[i], lam_ref[j], 'wo', markersize=10)
             if lambda_label is None:
@@ -310,7 +316,6 @@ def plot_2D_marginal_probs(marginals, bins, sample_set,
             cb.set_label(label_cbar, size=20)
             plt.axis([lam_domain[i][0], lam_domain[i][1], lam_domain[j][0],
                 lam_domain[j][1]]) 
-            plt.tight_layout()
             fig.savefig(filename + "_2D_" + str(i) + "_" + str(j) +\
                     file_extension, transparent=True)
             if interactive:
@@ -440,3 +445,115 @@ def smooth_marginals_2D(marginals, bins, sigma=10.0):
     return marginals_smooth
 
 
+def plot_2D_marginal_contours(marginals, bins, sample_set,
+                              contour_num = 8, 
+                              lam_ref=None, lam_refs = None,
+                              plot_domain = None,
+                              interactive=False,
+                              lambda_label=None, 
+                              contour_font_size = 20,
+                              filename="file", 
+                              file_extension=".png"):
+        
+    """
+    This makes contour plots of every pair of marginals (or joint in 2d case) 
+    of input probability measure on a rectangular grid.
+    If the sample_set object is a discretization object, we assume
+    that the probabilities to be plotted are from the input space.
+
+    .. note::
+
+        Do not specify the file extension in the file name.
+
+    :param marginals: 2D marginal probabilities
+    :type marginals: dictionary with tuples of 2 integers as keys and
+        :class:`~numpy.ndarray` of shape (nbins+1,) as values 
+    :param bins: Endpoints of bins used in calculating marginals
+    :type bins: :class:`~numpy.ndarray` of shape (nbins+1,2)
+    :param sample_set: Object containing samples and probabilities
+    :type sample_set: :class:`~bet.sample.sample_set_base` 
+        or :class:`~bet.sample.discretization`
+    :param filename: Prefix for output files.
+    :type filename: str
+    :param lam_ref: True parameters.
+    :type lam_ref: :class:`~numpy.ndarray` of shape (ndim,) or None
+    :param interactive: Whether or not to display interactive plots.
+    :type interactive: bool
+    :param lambda_label: Label for each parameter for plots.
+    :type lambda_label: list of length nbins of strings or None
+    :param string file_extension: file extenstion
+
+    """
+    if isinstance(sample_set, sample.discretization):
+        sample_obj = sample_set._input_sample_set
+    elif isinstance(sample_set, sample.sample_set_base):
+        sample_obj = sample_set
+    else:
+        raise bad_object("Improper sample object")
+
+    if lam_ref is None:
+        lam_ref = sample_obj._reference_value
+
+    lam_domain = sample_obj.get_domain()
+  
+    matplotlib.rcParams['xtick.direction'] = 'out'
+    matplotlib.rcParams['ytick.direction'] = 'out'
+    matplotlib.rcParams.update({'figure.autolayout': True})
+    
+    if comm.rank == 0:
+        pairs = copy.deepcopy(marginals.keys())
+        pairs.sort()
+        for k, (i, j) in enumerate(pairs):
+            fig = plt.figure(k)
+            ax = fig.add_subplot(111)
+            boxSize = (bins[i][1]-bins[i][0])*(bins[j][1]-bins[j][0])
+            nx = len(bins[i])-1
+            ny = len(bins[j])-1
+            dx = bins[i][1] - bins[i][0]
+            dy = bins[j][1] - bins[j][0]
+
+            x_kernel = np.linspace(-nx*dx/2, nx*dx/2, nx)
+            y_kernel = np.linspace(-ny*dy/2, ny*dy/2, ny)
+            X, Y = np.meshgrid(x_kernel, y_kernel, indexing='ij')
+            quadmesh = ax.contour(marginals[(i, j)].transpose()/boxSize,
+                    contour_num, colors='k', 
+                    extent=[lam_domain[i][0], lam_domain[i][1],
+                    lam_domain[j][0], lam_domain[j][1]], origin='lower',
+                    vmax=marginals[(i, j)].max()/boxSize, vmin=0, 
+                    aspect='auto')
+            if lam_refs is not None:
+                ax.plot(lam_refs[:,i], lam_refs[:,j], 'wo', markersize=20)
+            if lam_ref is not None:
+                ax.plot(lam_ref[i], lam_ref[j], 'ko', markersize=20)
+            if lambda_label is None:
+                label1 = r'$\lambda_{' + str(i+1) + '}$'
+                label2 = r'$\lambda_{' + str(j+1) + '}$'
+            else:
+                label1 = lambda_label[i]
+                label2 = lambda_label[j]
+            ax.set_xlabel(label1, fontsize=30) 
+            ax.set_ylabel(label2, fontsize=30)
+            ax.tick_params(axis='both', which='major', 
+                           labelsize=20)
+            plt.clabel(quadmesh, fontsize=contour_font_size, 
+                       inline=1, style='sci')
+            
+#            label_cbar = r'$\rho_{\lambda_{' + str(i+1) + '}, ' 
+#            label_cbar += r'\lambda_{' + str(j+1) + '}' + '}$ (Lebesgue)'
+#            cb = fig.colorbar(quadmesh, ax=ax, label=label_cbar)
+#            cb.ax.tick_params(labelsize=14)
+#            cb.set_label(label_cbar, size=20)
+            if plot_domain is None:
+                plt.axis([lam_domain[i][0], lam_domain[i][1], 
+                          lam_domain[j][0], lam_domain[j][1]]) 
+            else:
+                plt.axis([plot_domain[i][0], plot_domain[i][1], 
+                          plot_domain[j][0], plot_domain[j][1]]) 
+            fig.savefig(filename + "_2D_contours_" + str(i) + "_" + str(j) +\
+                    file_extension, transparent=True)
+            if interactive:
+                plt.show()
+            else:
+                plt.close()
+ 
+    comm.barrier()

--- a/bet/sampling/basicSampling.py
+++ b/bet/sampling/basicSampling.py
@@ -199,18 +199,13 @@ def regular_sample_set(input_obj, num_samples_per_dim=1):
             input_domain[i, 1] + 0.5 * bin_width,
             num_samples_per_dim[i] + 2))[1:num_samples_per_dim[i] + 1]
 
-    if np.equal(dim, 1):
-        arrays_samples_dimension = np.array([vec_samples_dimension])
-    else:
-        arrays_samples_dimension = np.meshgrid(
+    arrays_samples_dimension = np.meshgrid(
             *[vec_samples_dimension[i] for i in np.arange(0, dim)],
             indexing='ij')
 
-    if np.equal(dim, 1):
-        input_values = arrays_samples_dimension.transpose()
-    else:
-        for i in np.arange(0, dim):
-            input_values[:, i:i+1] = np.vstack(arrays_samples_dimension[i]\
+
+    for i in np.arange(0, dim):
+    	input_values[:, i:i+1] = np.vstack(arrays_samples_dimension[i]\
                     .flat[:])
 
     input_sample_set.set_values(input_values)

--- a/examples/FEniCS/BET_script.py
+++ b/examples/FEniCS/BET_script.py
@@ -97,12 +97,13 @@ param_ref = np.ones((1,num_KL_terms))
 Q_ref = my_model(param_ref)
 
 # Create some plots of input and output discretizations
-#plotD.scatter_2D(input_samples, ref_sample=param_ref[0,:],
-#                 filename='FEniCS_ParameterSamples',
-#                 file_extension = '.eps')
-#if Q_ref.size == 2:
-#    plotD.show_data_domain_2D(my_discretization, Q_ref=Q_ref[0,:],
-#            file_extension=".eps")
+if num_KL_terms == 2:
+    plotD.scatter_2D(input_samples, ref_sample=param_ref[0,:],
+                 filename='FEniCS_ParameterSamples',
+                 file_extension = '.eps')
+if Q_ref.size == 2:
+    plotD.show_data_domain_2D(my_discretization, Q_ref=Q_ref[0,:],
+            file_extension=".eps")
 
 
 '''
@@ -135,22 +136,20 @@ calculateP.prob(my_discretization)
 marginals2D = plotP.smooth_marginals_2D(marginals2D, bins, sigma=0.5)
 
 # plot 2d marginals probs
-#plotP.plot_2D_marginal_probs(marginals2D, bins, input_samples,
-#                             filename="FEniCS",
-#                             lam_ref=param_ref[0,:],
-#                             file_extension=".eps",
-#                             plot_surface=False)
+plotP.plot_2D_marginal_probs(marginals2D, bins, input_samples,
+                             filename="FEniCS",
+                             lam_ref=param_ref[0,:],
+                             file_extension=".eps",
+                             plot_surface=False)
 
 # calculate 1d marginal probs
 (bins, marginals1D) = plotP.calculate_1D_marginal_probs(input_samples,
                                                         nbins=20)
 # smooth 1d marginal probs (optional)
 marginals1D = plotP.smooth_marginals_1D(marginals1D, bins, sigma=0.5)
-# plot 2d marginal probs
-#plotP.plot_1D_marginal_probs(marginals1D, bins, input_samples,
-#                             filename="FEniCS",
-#                             lam_ref=param_ref[0,:],
-#                             file_extension=".eps")
-
-
+# plot 1d marginal probs
+plotP.plot_1D_marginal_probs(marginals1D, bins, input_samples,
+                             filename="FEniCS",
+                             lam_ref=param_ref[0,:],
+                             file_extension=".eps")
 

--- a/examples/FEniCS/BET_script.py
+++ b/examples/FEniCS/BET_script.py
@@ -97,12 +97,13 @@ param_ref = np.ones((1,num_KL_terms))
 Q_ref = my_model(param_ref)
 
 # Create some plots of input and output discretizations
-plotD.scatter_2D(input_samples, ref_sample=param_ref[0,:],
-                 filename='FEniCS_ParameterSamples',
-                 file_extension = '.eps')
-if Q_ref.size == 2:
-    plotD.show_data_domain_2D(my_discretization, Q_ref=Q_ref[0,:],
-            file_extension=".eps")
+#plotD.scatter_2D(input_samples, ref_sample=param_ref[0,:],
+#                 filename='FEniCS_ParameterSamples',
+#                 file_extension = '.eps')
+#if Q_ref.size == 2:
+#    plotD.show_data_domain_2D(my_discretization, Q_ref=Q_ref[0,:],
+#            file_extension=".eps")
+
 
 '''
 Suggested changes for user:
@@ -134,11 +135,11 @@ calculateP.prob(my_discretization)
 marginals2D = plotP.smooth_marginals_2D(marginals2D, bins, sigma=0.5)
 
 # plot 2d marginals probs
-plotP.plot_2D_marginal_probs(marginals2D, bins, input_samples,
-                             filename="FEniCS",
-                             lam_ref=param_ref[0,:],
-                             file_extension=".eps",
-                             plot_surface=False)
+#plotP.plot_2D_marginal_probs(marginals2D, bins, input_samples,
+#                             filename="FEniCS",
+#                             lam_ref=param_ref[0,:],
+#                             file_extension=".eps",
+#                             plot_surface=False)
 
 # calculate 1d marginal probs
 (bins, marginals1D) = plotP.calculate_1D_marginal_probs(input_samples,
@@ -146,10 +147,10 @@ plotP.plot_2D_marginal_probs(marginals2D, bins, input_samples,
 # smooth 1d marginal probs (optional)
 marginals1D = plotP.smooth_marginals_1D(marginals1D, bins, sigma=0.5)
 # plot 2d marginal probs
-plotP.plot_1D_marginal_probs(marginals1D, bins, input_samples,
-                             filename="FEniCS",
-                             lam_ref=param_ref[0,:],
-                             file_extension=".eps")
+#plotP.plot_1D_marginal_probs(marginals1D, bins, input_samples,
+#                             filename="FEniCS",
+#                             lam_ref=param_ref[0,:],
+#                             file_extension=".eps")
 
 
 

--- a/examples/FEniCS/BET_script.py
+++ b/examples/FEniCS/BET_script.py
@@ -64,9 +64,11 @@ per dimension (be careful if the dimension is not 2).
 # Generate samples on the parameter space
 randomSampling = False
 if randomSampling is True:
-    input_samples = sampler.random_sample_set('random', input_samples, num_samples=1E2)
+    input_samples = sampler.random_sample_set('random', 
+                                              input_samples, num_samples=1E2)
 else:
-    input_samples = sampler.regular_sample_set(input_samples, num_samples_per_dim=[10, 10])
+    input_samples = sampler.regular_sample_set(input_samples, 
+                                               num_samples_per_dim=[10, 10])
 
 '''
 A standard Monte Carlo (MC) assumption is that every Voronoi cell

--- a/examples/FEniCS/Compute_Save_KL.py
+++ b/examples/FEniCS/Compute_Save_KL.py
@@ -54,7 +54,8 @@ def computeSaveKL(numKL):
              ex=etaX,ey=etaY, C=C)
     '''
     # An Exponential Covariance
-    cov = Expression("C*exp(-fabs(x[0]-x[1])/ex - fabs(x[2]-x[3])/ey)",ex=etaX,ey=etaY, C=C)
+    cov = Expression("C*exp(-fabs(x[0]-x[1])/ex - fabs(x[2]-x[3])/ey)",ex=etaX,ey=etaY, C=C, \
+	degree = 10)
 
     # Solve the discrete covariance relation on the mesh
     Lmesh.projectCovToMesh(numKL,cov)

--- a/examples/FEniCS/myModel.py
+++ b/examples/FEniCS/myModel.py
@@ -96,8 +96,8 @@ def my_model(parameter_samples):
         return v
 
     # Define the QoI maps
-    Chi_1 = CharFunc(degree=1, region = [0.75, 1.25, 7.75, 8.25])
-    Chi_2 = CharFunc(degree=1, region = [7.75, 8.25, 0.75, 1.25])
+    Chi_1 = CharFunc(degree=1, region=[0.75, 1.25, 7.75, 8.25])
+    Chi_2 = CharFunc(degree=1, region=[7.75, 8.25, 0.75, 1.25])
 
     QoI_samples = np.zeros([numSamples,2])
 
@@ -130,3 +130,4 @@ def my_model(parameter_samples):
 
 
     return QoI_samples
+    

--- a/examples/FEniCS/myModel.py
+++ b/examples/FEniCS/myModel.py
@@ -83,7 +83,8 @@ def my_model(parameter_samples):
 
     # Setup the QoI class
     class CharFunc(Expression):
-      def __init__(self, region):
+      def __init__(self, **kwargs):
+        region = kwargs["region"]
         self.a = region[0]
         self.b = region[1]
         self.c = region[2]
@@ -95,8 +96,8 @@ def my_model(parameter_samples):
         return v
 
     # Define the QoI maps
-    Chi_1 = CharFunc([0.75, 1.25, 7.75, 8.25])
-    Chi_2 = CharFunc([7.75, 8.25, 0.75, 1.25])
+    Chi_1 = CharFunc(degree=1, region = [0.75, 1.25, 7.75, 8.25])
+    Chi_2 = CharFunc(degree=1, region = [7.75, 8.25, 0.75, 1.25])
 
     QoI_samples = np.zeros([numSamples,2])
 
@@ -121,7 +122,7 @@ def my_model(parameter_samples):
         perm_k.vector()[:] = perm_k_array
 
         # solve Poisson with this random field using FEM
-        u = solvePoissonRandomField(perm_k, mesh, 1, f, bcs)
+        u = solvePoissonRandomField(perm_k, V, f, bcs)
 
         # Compute QoI
         QoI_samples[i, 0] = assemble(u * Chi_1 * dx)

--- a/examples/FEniCS/myModel.py
+++ b/examples/FEniCS/myModel.py
@@ -91,7 +91,8 @@ def my_model(parameter_samples):
         self.d = region[3]
       def eval(self, v, x):
         v[0] = 0
-        if (x[0] >= self.a) & (x[0] <= self.b) & (x[1] >= self.c) & (x[1] <= self.d):
+        if (x[0] >= self.a) and (x[0] <= self.b) and (x[1] >= self.c)\
+            and (x[1] <= self.d):
           v[0] = 1
         return v
 

--- a/examples/FEniCS/poissonRandField.py
+++ b/examples/FEniCS/poissonRandField.py
@@ -1,12 +1,11 @@
 from dolfin import*
 
-def solvePoissonRandomField(rand_field,mesh,poly_order,f,bcs):
+def solvePoissonRandomField(rand_field,V,f,bcs):
     """
     Solves the poisson equation with a random field :
     (\grad \dot (rand_field \grad(u)) = -f)
     """
     # create the function space
-    V = FunctionSpace(mesh, "CG", poly_order)
     u = TrialFunction(V)
     v = TestFunction(V)
     L = f*v*dx

--- a/test/test_postProcess/test_plotP.py
+++ b/test/test_postProcess/test_plotP.py
@@ -237,3 +237,4 @@ class Test_calc_marg_2D(unittest.TestCase):
         except (RuntimeError, TypeError, NameError):
             go = False
         nptest.assert_equal(go, True)
+        

--- a/test/test_postProcess/test_plotP.py
+++ b/test/test_postProcess/test_plotP.py
@@ -34,13 +34,15 @@ class Test_calc_marg_1D(unittest.TestCase):
 
         num_samples=1000
 
-        emulated_input_samples.set_values_local(np.linspace(emulated_input_samples.get_domain()[0][0],
-                                             emulated_input_samples.get_domain()[0][1],
-                                             num_samples+1))
+        emulated_input_samples.set_values_local(
+                        np.linspace(emulated_input_samples.get_domain()[0][0],
+                                    emulated_input_samples.get_domain()[0][1],
+                                    num_samples+1))
 
-        emulated_input_samples.set_probabilities_local(1.0/float(comm.size)*(1.0/float(\
-                emulated_input_samples.get_values_local().shape[0]))\
-                *np.ones((emulated_input_samples.get_values_local().shape[0],)))
+        emulated_input_samples.set_probabilities_local(
+                1.0/float(comm.size)*(1.0/float(\
+                emulated_input_samples.get_values_local().shape[0]))*\
+                np.ones((emulated_input_samples.get_values_local().shape[0],)))
 
         emulated_input_samples.check_num()
 
@@ -79,14 +81,27 @@ class Test_calc_marg_2D(unittest.TestCase):
         emulated_input_samples = sample.sample_set(2)
         emulated_input_samples.set_domain(np.array([[0.0,1.0],[0.0,1.0]]))
 
-        emulated_input_samples.set_values_local(util.meshgrid_ndim((np.linspace(emulated_input_samples.get_domain()[0][0],
-            emulated_input_samples.get_domain()[0][1], 10),
-            np.linspace(emulated_input_samples.get_domain()[1][0],
-                emulated_input_samples.get_domain()[1][1], 10))))
+        emulated_input_samples.set_values_local(
+            util.meshgrid_ndim((np.linspace(
+                                    emulated_input_samples.get_domain()[0][0],
+                                    emulated_input_samples.get_domain()[0][1], 
+                                    10),
+                                np.linspace(
+                                    emulated_input_samples.get_domain()[1][0],
+                                    emulated_input_samples.get_domain()[1][1], 
+                                    10)
+                               ))
+                                               )
 
         emulated_input_samples.set_probabilities_local(1.0/float(comm.size)*\
-                (1.0/float(emulated_input_samples.get_values_local().shape[0]))*\
-                np.ones((emulated_input_samples.get_values_local().shape[0],)))
+                (
+                 1.0/float(\
+                    emulated_input_samples.get_values_local().shape[0])
+                )*\
+                 np.ones(
+                    (emulated_input_samples.get_values_local().shape[0],)
+                        )
+                                                      )
         emulated_input_samples.check_num()
 
         self.samples = emulated_input_samples
@@ -152,7 +167,8 @@ class Test_calc_marg_2D(unittest.TestCase):
         (bins, marginals) = plotP.calculate_1D_marginal_probs(self.samples,
                                                               nbins = 10)
 
-        marginals_smooth = plotP.smooth_marginals_1D(marginals, bins, sigma = 10.0)
+        marginals_smooth = plotP.smooth_marginals_1D(marginals, bins, 
+                                                     sigma = 10.0)
 
         nptest.assert_equal(marginals_smooth[0].shape,  marginals[0].shape)
         nptest.assert_almost_equal(np.sum(marginals_smooth[0]), 1.0)
@@ -164,9 +180,11 @@ class Test_calc_marg_2D(unittest.TestCase):
         (bins, marginals) = plotP.calculate_2D_marginal_probs(self.samples,
                                                               nbins = 10)
 
-        marginals_smooth = plotP.smooth_marginals_2D(marginals, bins, sigma = 10.0)
+        marginals_smooth = plotP.smooth_marginals_2D(marginals, bins, 
+                                                     sigma = 10.0)
 
-        nptest.assert_equal(marginals_smooth[(0,1)].shape,  marginals[(0,1)].shape)
+        nptest.assert_equal(marginals_smooth[(0,1)].shape,  
+                            marginals[(0,1)].shape)
         nptest.assert_almost_equal(np.sum(marginals_smooth[(0,1)]), 1.0)
 
     def test_plot_marginals_1D(self):
@@ -202,3 +220,20 @@ class Test_calc_marg_2D(unittest.TestCase):
             go = False
         nptest.assert_equal(go, True)
 
+    def test_plot_2D_marginal_contours(self):
+        """
+        Test :meth:`bet.postProcess.plotP.plot_2D_marginal_contours`.
+        """
+        (bins, marginals) = plotP.calculate_2D_marginal_probs(self.samples,
+                                                              nbins = 10)
+        marginals[(0,1)][0][0]=0.0
+        marginals[(0,1)][0][1]*=2.0
+        try:
+            plotP.plot_2D_marginal_probs(marginals, bins, self.samples,
+                                         filename = "file", interactive=False)
+            go = True
+            if os.path.exists("file_2D_contours_0_1.png") and comm.rank == 0:
+                os.remove("file_2D_contours_0_1.png")
+        except (RuntimeError, TypeError, NameError):
+            go = False
+        nptest.assert_equal(go, True)

--- a/test/test_sampling/test_basicSampling.py
+++ b/test/test_sampling/test_basicSampling.py
@@ -465,16 +465,10 @@ def verify_regular_sample_set(sampler, input_sample_set,
             test_domain[i, 1] + 0.5 * bin_width,
             num_samples_per_dim[i] + 2))[1:num_samples_per_dim[i] + 1]
 
-    if np.equal(dim, 1):
-        arrays_samples_dimension = np.array([vec_samples_dimension])
-    else:
-        arrays_samples_dimension = np.meshgrid(
+    arrays_samples_dimension = np.meshgrid(
             *[vec_samples_dimension[i] for i in np.arange(0, dim)], indexing='ij')
 
-    if np.equal(dim, 1):
-        test_values = arrays_samples_dimension.transpose()
-    else:
-        for i in np.arange(0, dim):
+    for i in np.arange(0, dim):
             test_values[:, i:i + 1] = np.vstack(arrays_samples_dimension[i].flat[:])
 
     test_sample_set.set_values(test_values)
@@ -519,17 +513,11 @@ def verify_regular_sample_set_domain(sampler, input_domain,
             test_domain[i, 1] + 0.5 * bin_width,
             num_samples_per_dim[i] + 2))[1:num_samples_per_dim[i] + 1]
 
-    if np.equal(dim, 1):
-        arrays_samples_dimension = np.array([vec_samples_dimension])
-    else:
-        arrays_samples_dimension = np.meshgrid(
+    arrays_samples_dimension = np.meshgrid(
             *[vec_samples_dimension[i] for i in np.arange(0, dim)], indexing='ij')
 
-    if np.equal(dim, 1):
-        test_values = arrays_samples_dimension.transpose()
-    else:
-        for i in np.arange(0, dim):
-            test_values[:, i:i + 1] = np.vstack(arrays_samples_dimension[i].flat[:])
+    for i in np.arange(0, dim):
+        test_values[:, i:i + 1] = np.vstack(arrays_samples_dimension[i].flat[:])
 
     test_sample_set.set_values(test_values)
 
@@ -574,17 +562,11 @@ def verify_regular_sample_set_dimension(sampler, input_dim,
             test_domain[i, 1] + 0.5 * bin_width,
             num_samples_per_dim[i] + 2))[1:num_samples_per_dim[i] + 1]
 
-    if np.equal(dim, 1):
-        arrays_samples_dimension = np.array([vec_samples_dimension])
-    else:
-        arrays_samples_dimension = np.meshgrid(
+    arrays_samples_dimension = np.meshgrid(
             *[vec_samples_dimension[i] for i in np.arange(0, dim)], indexing='ij')
 
-    if np.equal(dim, 1):
-        test_values = arrays_samples_dimension.transpose()
-    else:
-        for i in np.arange(0, dim):
-            test_values[:, i:i + 1] = np.vstack(arrays_samples_dimension[i].flat[:])
+    for i in np.arange(0, dim):
+        test_values[:, i:i + 1] = np.vstack(arrays_samples_dimension[i].flat[:])
 
     test_sample_set.set_values(test_values)
 


### PR DESCRIPTION
The 1D regular sampling was not producing arrays correctly. Now fixed. It works in 1D examples now (which we still do not have, so should probably add at some point). 

The FEniCS example had to be updated in just a few places to work with the newer version of FEniCS. 