### PR TITLE
Travis updated to new distribution

### DIFF
--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+flake8:
+  enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -10,7 +10,7 @@ services:
 
 before_install:
   - "export DISPLAY=:99.0"
-  - sudo apt-get install gfortran libblas-dev liblapack-dev mpich2 libmpich2-dev
+  - sudo apt-get install gfortran libblas-dev liblapack-dev mpich libmpich-dev
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda
   - export PATH="$HOME/miniconda/bin:$PATH"

--- a/.travis.yml
+++ b/.travis.yml
@@ -11,13 +11,8 @@ services:
 before_install:
   - "export DISPLAY=:99.0"
   - sudo apt-get install gfortran libblas-dev liblapack-dev mpich libmpich-dev
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - conda update --yes conda
 
 install:
-  - pip install setuptools
   - pip install numpy scipy matplotlib pyDOE mpi4py nose codecov
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ dist: xenial
 language: python
 python:
     - "2.7"
+    - "3.5"
     - "3.6"
     - "3.7"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,6 +17,7 @@ before_install:
   - conda update --yes conda
 
 install:
+  - pip install --upgrade setuptools
   - pip install numpy scipy matplotlib pyDOE mpi4py nose codecov
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -5,9 +5,11 @@ python:
     - "3.6"
     - "3.7"
 
+services:
+  - xvfb
+
 before_install:
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
   - sudo apt-get install gfortran libblas-dev liblapack-dev mpich2 libmpich2-dev
   - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
   - bash miniconda.sh -b -p $HOME/miniconda

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,7 +2,6 @@ dist: xenial
 language: python
 python:
     - "2.7"
-    - "3.5"
     - "3.6"
     - "3.7"
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,18 +1,19 @@
-dist: xenial
 language: python
 python:
     - "2.7"
     - "3.6"
-    - "3.7"
-
-services:
-  - xvfb
 
 before_install:
   - "export DISPLAY=:99.0"
-  - sudo apt-get install gfortran libblas-dev liblapack-dev mpich libmpich-dev
+  - "sh -e /etc/init.d/xvfb start"
+  - sudo apt-get install gfortran libblas-dev liblapack-dev mpich2 libmpich2-dev
+  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
+  - bash miniconda.sh -b -p $HOME/miniconda
+  - export PATH="$HOME/miniconda/bin:$PATH"
+  - conda update --yes conda
 
 install:
+  - conda create -y -n travispy python=$TRAVIS_PYTHON_VERSION pip && source activate travispy
   - pip install numpy scipy matplotlib pyDOE mpi4py nose codecov
   - python setup.py install
 
@@ -37,7 +38,8 @@ notifications:
 branches:
     only:
         - master
-        - v2_master
+        - metrics
+        - linting
 
 # Push the results back to codecov
 after_success:

--- a/.travis.yml
+++ b/.travis.yml
@@ -17,7 +17,7 @@ before_install:
   - conda update --yes conda
 
 install:
-  - pip install --upgrade setuptools
+  - pip install setuptools
   - pip install numpy scipy matplotlib pyDOE mpi4py nose codecov
   - python setup.py install
 

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
+dist: xenial
 language: python
 python:
     - "2.7"
     - "3.6"
+    - "3.7"
 
 before_install:
   - "export DISPLAY=:99.0"
@@ -13,7 +15,6 @@ before_install:
   - conda update --yes conda
 
 install:
-  - conda create -y -n travispy python=$TRAVIS_PYTHON_VERSION pip && source activate travispy
   - pip install numpy scipy matplotlib pyDOE mpi4py nose codecov
   - python setup.py install
 


### PR DESCRIPTION
big changes to the file but a much better testing environment overall. Passes in 3.7 as well. 
If you'd like, we can add more experimental builds (such as nightly ones) but allow them to fail. 

Fails in 3.5. Should include in the documentation that Python 2.7+ or 3.6+ are required... 

I think we should also remove `v2_master`... 