### PR TITLE
bug fix for plotting notebook

### DIFF
--- a/examples/plotting/Plotting_Examples.ipynb
+++ b/examples/plotting/Plotting_Examples.ipynb
@@ -39,10 +39,11 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "folders = glob.glob('*/')\n",
+    "folders = glob.glob('../*')\n",
+    "folders = [f.replace('../','')+'/' for f in folders]\n",
     "# files irrelevant to examples\n",
     "folders.remove('matfiles/')\n",
-    "folders.remove('figs/')\n",
+    "folders.remove('plotting/')\n",
     "folders.remove('parallel_and_serial_sampling/')\n",
     "# needs work\n",
     "# folders.remove('sensitivity/') # heatmap and linear\n",
@@ -71,7 +72,7 @@
     "user_selection = 3\n",
     "########################################\n",
     "\n",
-    "folder = folders[user_selection]\n",
+    "folder = '../'+folders[user_selection]\n",
     "notebook_files = glob.glob('%s/*.ipynb'%folder)\n",
     "print(\"You have selected %s. The files inside are:\\n\"%folder, *notebook_files)"
    ]

--- a/examples/plotting/Plotting_Examples.ipynb
+++ b/examples/plotting/Plotting_Examples.ipynb
@@ -9,7 +9,8 @@
     "Copyright (C) 2014-2019 The BET Development Team\n",
     "\n",
     "This notebook demonstrates how to visualize the spaces involved in the stochastic inverse problem.\n",
-    "We leverage some Jupyter `%magics` to load in data files using `%store -r` to recover `bet.sample.discretization` objects from other Example Notebooks."
+    "We leverage some Jupyter `%magics` to load in data files using `%store -r` to recover `bet.sample.discretization` objects from other Example Notebooks.\n",
+    "This notebook makes strong assumptions about directory structure. It may not work if moved.\n"
    ]
   },
   {
@@ -44,6 +45,7 @@
     "# files irrelevant to examples\n",
     "folders.remove('matfiles/')\n",
     "folders.remove('plotting/')\n",
+    "folders.remove('templates/')\n",
     "folders.remove('parallel_and_serial_sampling/')\n",
     "# needs work\n",
     "# folders.remove('sensitivity/') # heatmap and linear\n",
@@ -324,7 +326,7 @@
     "\n",
     "    # plot 2d marginals probs\n",
     "    plotP.plot_2D_marginal_probs(marginals2D, bins, input_samples, \n",
-    "                    filename = '%s%s_raw'%(folder, folder[:-1]),\n",
+    "                    filename = '%s%s_raw'%(folder, folder[3:-1]),\n",
     "                    file_extension = '.png', plot_surface=False)\n",
     "\n",
     "    # smooth 2d marginals probs (optional)\n",
@@ -332,7 +334,7 @@
     "\n",
     "    # plot 2d marginals probs\n",
     "    plotP.plot_2D_marginal_probs(marginals2D, bins, input_samples, \n",
-    "                    filename = '%s%s_smooth'%(folder, folder[:-1]), \n",
+    "                    filename = '%s%s_smooth'%(folder, folder[3:-1]), \n",
     "                    file_extension = '.png', plot_surface=False)"
    ]
   },
@@ -366,7 +368,7 @@
     "\n",
     "# plot 1d marginal probs\n",
     "plotP.plot_1D_marginal_probs(marginals1D, bins, input_samples,\n",
-    "                             filename = '%s%s_raw'%(folder, folder[:-1]),\n",
+    "                             filename = '%s%s_raw'%(folder, folder[3:-1]),\n",
     "                             file_extension = '.png')\n",
     "\n",
     "# smooth 1d marginal probs (optional)\n",
@@ -374,7 +376,7 @@
     "\n",
     "# plot 2d marginal probs\n",
     "plotP.plot_1D_marginal_probs(marginals1D, bins, input_samples,\n",
-    "                             filename = '%s%s_smooth'%(folder, folder[:-1]),\n",
+    "                             filename = '%s%s_smooth'%(folder, folder[3:-1]),\n",
     "                             file_extension = '.png')\n"
    ]
   },
@@ -391,7 +393,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for f in glob.glob('%s%s_raw_1D*'%(folder, folder[:-1])):\n",
+    "for f in glob.glob('%s%s_raw_1D*'%(folder, folder[3:-1])):\n",
     "    print(f)\n",
     "    display(Image(f))"
    ]
@@ -409,7 +411,7 @@
    "metadata": {},
    "outputs": [],
    "source": [
-    "for f in glob.glob('%s%s_smooth_1D*'%(folder, folder[:-1])):\n",
+    "for f in glob.glob('%s%s_smooth_1D*'%(folder, folder[3:-1])):\n",
     "    print(f)\n",
     "    display(Image(f))"
    ]


### PR DESCRIPTION
After moving `Plotting_Examples.ipynb` into the `plotting` folder, the path structure assumptions were no longer true. This has been fixed now to reflect the new directory structure. 