### PR TITLE
new xenial build.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,19 +1,18 @@
+dist: xenial
 language: python
 python:
     - "2.7"
     - "3.6"
+    - "3.7"
+
+services:
+  - xvfb
 
 before_install:
   - "export DISPLAY=:99.0"
-  - "sh -e /etc/init.d/xvfb start"
-  - sudo apt-get install gfortran libblas-dev liblapack-dev mpich2 libmpich2-dev
-  - wget http://repo.continuum.io/miniconda/Miniconda-latest-Linux-x86_64.sh -O miniconda.sh
-  - bash miniconda.sh -b -p $HOME/miniconda
-  - export PATH="$HOME/miniconda/bin:$PATH"
-  - conda update --yes conda
+  - sudo apt-get install gfortran libblas-dev liblapack-dev mpich libmpich-dev
 
 install:
-  - conda create -y -n travispy python=$TRAVIS_PYTHON_VERSION pip && source activate travispy
   - pip install numpy scipy matplotlib pyDOE mpi4py nose codecov
   - python setup.py install
 
@@ -38,7 +37,6 @@ notifications:
 branches:
     only:
         - master
-        - v2_master
 
 # Push the results back to codecov
 after_success:


### PR DESCRIPTION
clean commit. 
In order to test Python 3.7, Travis requires the use of their new `xenial` dist. I have followed their guidelines for setting this up and resolved all the differences between the two. So, this will future-proof our CI for a while. (3.8 is already available there, will never be on the build we use now). 

Notable differences: There is no more need to install miniconda in order to handle the version control. The dist specified in the `python` section now works as was supposed to instead of simply acting as an argument to conda. 

removing `v2_master` because it is out of date. 

I request permission to add a `whitelist` branch here so that I can have travis check my builds without requesting PRs into master. Perhaps... `dev`, which I can at least use as a staging ground for practice PRs for adding new features. My thinking is that I can propose new features into the `dev` branch, and submit PRs into them (in my fork), so that I can keep my `master` even with this one. I just need a way to get CI set up in my fork and still keep master clean... 