### PR TITLE
uncaught typo

### DIFF
--- a/bet/sample.py
+++ b/bet/sample.py
@@ -1750,7 +1750,7 @@ class voronoi_sample_set(sample_set_base):
             msg = "These sample sets must have the same dimension."
             raise dim_not_matching(msg)
         # check domain
-        if self._domain is not None and sset_._domain is not None:
+        if self._domain is not None and sset._domain is not None:
             if not np.allclose(self._domain, sset._domain):
                 msg = "These sample sets have different domains."
                 raise domain_not_matching(msg)

--- a/bet/sample.py
+++ b/bet/sample.py
@@ -1750,7 +1750,7 @@ class voronoi_sample_set(sample_set_base):
             msg = "These sample sets must have the same dimension."
             raise dim_not_matching(msg)
         # check domain
-        if self._domain is not None and sset_.domain is not None:
+        if self._domain is not None and sset_._domain is not None:
             if not np.allclose(self._domain, sset._domain):
                 msg = "These sample sets have different domains."
                 raise domain_not_matching(msg)


### PR DESCRIPTION
no test for this according to coverage report, so unsurprising that it didn't get caught. I copy/pasted it for something else and ran into the `AttributeError`. 
I performed a `grep -rni` on that string and this seems to be the only place it happens.
```
[BET]$ grep -rni 'sset_.domain'
bet/.ipynb_checkpoints/sample-checkpoint.py:1753:        if self._domain is not None and sset_.domain is not None:
bet/sample.py.bak:1751:        if self._domain is not None and sset_.domain is not None:
bet/sample.py:1753:        if self._domain is not None and sset_.domain is not None:
build/lib/bet/sample.py:1753:        if self._domain is not None and sset_.domain is not None:
```

