### PR TITLE
clipping sample sets creates bug in query.

### DIFF
--- a/bet/sample.py
+++ b/bet/sample.py
@@ -609,6 +609,7 @@ class sample_set_base(object):
                 setattr(sset, array_name, new_array)
         if sset._values_local is not None:
             sset.global_to_local()
+        sset.set_kdtree()
         return sset
 
     def check_num(self):


### PR DESCRIPTION
If you create a clipping of a sample set, and then query a set of values, it will return indices into the original set, ignoring the fact that kdtree_values is shorter. 
**Since copy is called before the values are truncated, the kdtree object is associated with the original samples.**

this was a malicious bug to catch... only when I was trying to get to the final lines of my coverage for metric did I find this. One of the tests I wrote used clip, and I kept getting dimension errors. The query function is a core piece of the functionality of my metric class, so the test associated with its use was the one that was failing, but it was many layers down. Had to dig really deep to track this one down.