### PR TITLE
reference parameter synergy between simpleFunP and sampling

### DIFF
--- a/bet/calculateP/simpleFunP.py
+++ b/bet/calculateP/simpleFunP.py
@@ -19,13 +19,15 @@ class wrong_argument_type(Exception):
     types.
     """
 
+
 def infer_Q(data_set):
     if isinstance(data_set, samp.sample_set_base):
-            return data_set.get_reference_value()
-        elif isinstance(data_set, samp.discretization):
-            return data_set._output_sample_set.get_reference_value()
-        else:
-            return None
+        return data_set.get_reference_value()
+    elif isinstance(data_set, samp.discretization):
+        return data_set._output_sample_set.get_reference_value()
+    else:
+        return None
+
 
 def check_inputs(data_set, Q_ref):
     """

--- a/bet/calculateP/simpleFunP.py
+++ b/bet/calculateP/simpleFunP.py
@@ -19,6 +19,13 @@ class wrong_argument_type(Exception):
     types.
     """
 
+def infer_Q(data_set):
+    if isinstance(data_set, samp.sample_set_base):
+            return data_set.get_reference_value()
+        elif isinstance(data_set, samp.discretization):
+            return data_set._output_sample_set.get_reference_value()
+        else:
+            return None
 
 def check_inputs(data_set, Q_ref):
     """
@@ -130,12 +137,7 @@ def uniform_partition_uniform_distribution_rectangle_size(data_set,
     :returns: sample_set object defininng simple function approximation
     """
     if Q_ref is None:
-        if isinstance(data_set, samp.sample_set_base):
-            Q_ref = data_set.get_reference_value()
-        elif isinstance(data_set, samp.discretization):
-            Q_ref = data_set._output_sample_set.get_reference_value()
-        else:
-            pass
+        Q_ref = infer_Q(data_set)
     (num, dim, values, Q_ref) = check_inputs(data_set, Q_ref)
 
     if rect_size is None:
@@ -266,12 +268,7 @@ def uniform_partition_uniform_distribution_rectangle_scaled(data_set,
     :returns: sample_set object defininng simple function approximation
     """
     if Q_ref is None:
-        if isinstance(data_set, samp.sample_set_base):
-            Q_ref = data_set.get_reference_value()
-        elif isinstance(data_set, samp.discretization):
-            Q_ref = data_set._output_sample_set.get_reference_value()
-        else:
-            pass
+        Q_ref = infer_Q(data_set)
     (num, dim, values, Q_ref) = check_inputs(data_set, Q_ref)
     rect_size = (np.max(values, 0) - np.min(values, 0))*rect_scale
 
@@ -355,12 +352,7 @@ def regular_partition_uniform_distribution_rectangle_size(data_set, Q_ref=None,
 
     """
     if Q_ref is None:
-        if isinstance(data_set, samp.sample_set_base):
-            Q_ref = data_set.get_reference_value()
-        elif isinstance(data_set, samp.discretization):
-            Q_ref = data_set._output_sample_set.get_reference_value()
-        else:
-            pass
+        Q_ref = infer_Q(data_set)
     (num, dim, values, Q_ref) = check_inputs(data_set, Q_ref)
 
     data = values
@@ -471,12 +463,7 @@ def regular_partition_uniform_distribution_rectangle_scaled(data_set,
 
     """
     if Q_ref is None:
-        if isinstance(data_set, samp.sample_set_base):
-            Q_ref = data_set.get_reference_value()
-        elif isinstance(data_set, samp.discretization):
-            Q_ref = data_set._output_sample_set.get_reference_value()
-        else:
-            pass
+        Q_ref = infer_Q(data_set)
     (num, dim, values, Q_ref) = check_inputs(data_set, Q_ref)
 
     data = values
@@ -563,12 +550,7 @@ def normal_partition_normal_distribution(data_set, Q_ref=None, std=1, M=1,
 
     """
     if Q_ref is None:
-        if isinstance(data_set, samp.sample_set_base):
-            Q_ref = data_set.get_reference_value()
-        elif isinstance(data_set, samp.discretization):
-            Q_ref = data_set._output_sample_set.get_reference_value()
-        else:
-            pass
+        Q_ref = infer_Q(data_set)
     import scipy.stats as stats
     r'''Create M smaples defining M bins in D used to define
     :math:`\rho_{\mathcal{D},M}` rho_D is assumed to be a multi-variate normal
@@ -670,12 +652,7 @@ def uniform_partition_normal_distribution(data_set, Q_ref=None, std=1, M=1,
     :math:`\rho_{\mathcal{D},M}` rho_D is assumed to be a multi-variate normal
     distribution with mean Q_ref and standard deviation std.'''
     if Q_ref is None:
-        if isinstance(data_set, samp.sample_set_base):
-            Q_ref = data_set.get_reference_value()
-        elif isinstance(data_set, samp.discretization):
-            Q_ref = data_set._output_sample_set.get_reference_value()
-        else:
-            pass
+        Q_ref = infer_Q(data_set)
     if not isinstance(Q_ref, collections.Iterable):
         Q_ref = np.array([Q_ref])
     if not isinstance(std, collections.Iterable):

--- a/bet/calculateP/simpleFunP.py
+++ b/bet/calculateP/simpleFunP.py
@@ -129,7 +129,13 @@ def uniform_partition_uniform_distribution_rectangle_size(data_set,
     :rtype: :class:`~bet.sample.voronoi_sample_set`
     :returns: sample_set object defininng simple function approximation
     """
-
+    if Q_ref is None:
+        if isinstance(data_set, samp.sample_set_base):
+            Q_ref = data_set.get_reference_value()
+        elif isinstance(data_set, samp.discretization):
+            Q_ref = data_set._output_sample_set.get_reference_value()
+        else:
+            pass
     (num, dim, values, Q_ref) = check_inputs(data_set, Q_ref)
 
     if rect_size is None:
@@ -259,6 +265,13 @@ def uniform_partition_uniform_distribution_rectangle_scaled(data_set,
     :rtype: :class:`~bet.sample.voronoi_sample_set`
     :returns: sample_set object defininng simple function approximation
     """
+    if Q_ref is None:
+        if isinstance(data_set, samp.sample_set_base):
+            Q_ref = data_set.get_reference_value()
+        elif isinstance(data_set, samp.discretization):
+            Q_ref = data_set._output_sample_set.get_reference_value()
+        else:
+            pass
     (num, dim, values, Q_ref) = check_inputs(data_set, Q_ref)
     rect_size = (np.max(values, 0) - np.min(values, 0))*rect_scale
 
@@ -341,6 +354,13 @@ def regular_partition_uniform_distribution_rectangle_size(data_set, Q_ref=None,
     :returns: sample_set object defining simple function approximation
 
     """
+    if Q_ref is None:
+        if isinstance(data_set, samp.sample_set_base):
+            Q_ref = data_set.get_reference_value()
+        elif isinstance(data_set, samp.discretization):
+            Q_ref = data_set._output_sample_set.get_reference_value()
+        else:
+            pass
     (num, dim, values, Q_ref) = check_inputs(data_set, Q_ref)
 
     data = values
@@ -420,8 +440,9 @@ def regular_partition_uniform_distribution_rectangle_domain(data_set,
                                                                  cells_per_dimension)
 
 
-def regular_partition_uniform_distribution_rectangle_scaled(data_set, Q_ref,
-                                                            rect_scale,
+def regular_partition_uniform_distribution_rectangle_scaled(data_set,
+                                                            Q_ref=None,
+                                                            rect_scale=1,
                                                             cells_per_dimension=1):
     r"""
     Creates a simple function approximation of :math:`\rho_{\mathcal{D},M}`
@@ -439,7 +460,7 @@ def regular_partition_uniform_distribution_rectangle_scaled(data_set, Q_ref,
     :type data_set: :class:`~bet.sample.discretization` or
         :class:`~bet.sample.sample_set` or :class:`~numpy.ndarray`
     :param rect_scale: The scale used to determine the width of the
-        uniform distributiion as ``rect_size = (data_max-data_min)*rect_scale``
+        uniform distribution as ``rect_size = (data_max-data_min)*rect_scale``
     :type rect_scale: double or list
     :param Q_ref: :math:`Q(\lambda_{reference})`
     :type Q_ref: :class:`~numpy.ndarray` of size (mdim,)
@@ -449,6 +470,13 @@ def regular_partition_uniform_distribution_rectangle_scaled(data_set, Q_ref,
     :returns: sample_set object defining simple function approximation
 
     """
+    if Q_ref is None:
+        if isinstance(data_set, samp.sample_set_base):
+            Q_ref = data_set.get_reference_value()
+        elif isinstance(data_set, samp.discretization):
+            Q_ref = data_set._output_sample_set.get_reference_value()
+        else:
+            pass
     (num, dim, values, Q_ref) = check_inputs(data_set, Q_ref)
 
     data = values
@@ -508,7 +536,7 @@ def uniform_partition_uniform_distribution_data_samples(data_set):
     return s_set
 
 
-def normal_partition_normal_distribution(data_set, Q_ref, std, M,
+def normal_partition_normal_distribution(data_set, Q_ref=None, std=1, M=1,
                                          num_d_emulate=1E6):
     r"""
     Creates a simple function approximation of :math:`\rho_{\mathcal{D},M}`
@@ -534,6 +562,13 @@ def normal_partition_normal_distribution(data_set, Q_ref, std, M,
     :returns: sample_set object defining simple function approximation
 
     """
+    if Q_ref is None:
+        if isinstance(data_set, samp.sample_set_base):
+            Q_ref = data_set.get_reference_value()
+        elif isinstance(data_set, samp.discretization):
+            Q_ref = data_set._output_sample_set.get_reference_value()
+        else:
+            pass
     import scipy.stats as stats
     r'''Create M smaples defining M bins in D used to define
     :math:`\rho_{\mathcal{D},M}` rho_D is assumed to be a multi-variate normal
@@ -604,7 +639,7 @@ def normal_partition_normal_distribution(data_set, Q_ref, std, M,
     return s_set
 
 
-def uniform_partition_normal_distribution(data_set, Q_ref, std, M,
+def uniform_partition_normal_distribution(data_set, Q_ref=None, std=1, M=1,
                                           num_d_emulate=1E6):
     r"""
     Creates a simple function approximation of :math:`\rho_{\mathcal{D},M}`
@@ -634,6 +669,13 @@ def uniform_partition_normal_distribution(data_set, Q_ref, std, M,
     r'''Create M samples defining M bins in D used to define
     :math:`\rho_{\mathcal{D},M}` rho_D is assumed to be a multi-variate normal
     distribution with mean Q_ref and standard deviation std.'''
+    if Q_ref is None:
+        if isinstance(data_set, samp.sample_set_base):
+            Q_ref = data_set.get_reference_value()
+        elif isinstance(data_set, samp.discretization):
+            Q_ref = data_set._output_sample_set.get_reference_value()
+        else:
+            pass
     if not isinstance(Q_ref, collections.Iterable):
         Q_ref = np.array([Q_ref])
     if not isinstance(std, collections.Iterable):

--- a/bet/calculateP/simpleFunP.py
+++ b/bet/calculateP/simpleFunP.py
@@ -685,15 +685,8 @@ def uniform_partition_normal_distribution(data_set, Q_ref=None, std=1, M=1,
     distribution with mean Q_ref and standard deviation std.'''
     if Q_ref is None:
         Q_ref = infer_Q(data_set)
-<<<<<<< HEAD
-    if not isinstance(Q_ref, collections.Iterable):
-        Q_ref = np.array([Q_ref])
-    if not isinstance(std, collections.Iterable):
-        std = np.array([std])
-=======
     Q_ref = check_type(Q_ref, data_set)
     std = check_type(std, data_set)
->>>>>>> master
 
     bin_size = 4.0 * std
     d_distr_samples = np.zeros((M, len(Q_ref)))

--- a/bet/sampling/basicSampling.py
+++ b/bet/sampling/basicSampling.py
@@ -380,6 +380,7 @@ class sampler(object):
 
         local_output = self.lb_model(
             input_sample_set.get_values_local())
+
         if isinstance(local_output, np.ndarray):
             local_output_values = local_output
         elif isinstance(local_output, tuple):
@@ -400,9 +401,11 @@ class sampler(object):
             output_dim = 1
         else:
             output_dim = local_output_values.shape[1]
+
         output_sample_set = sample.sample_set(output_dim)
         output_sample_set.set_values_local(local_output_values)
         lam_ref = input_sample_set._reference_value 
+
         if lam_ref is not None:
             try:
                 if not isinstance(lam_ref, collections.Iterable):
@@ -418,8 +421,10 @@ class sampler(object):
                     output_sample_set.set_reference_value(Q_ref)
                 except ValueError:
                     logging.log(20, 'Unable to map reference value.')
+
         if self.error_estimates:
             output_sample_set.set_error_estimates_local(local_output_ee)
+
         if self.jacobians:
             input_sample_set.set_jacobians_local(local_output_jac)
 
@@ -428,6 +433,7 @@ class sampler(object):
             output_sample_set.local_to_global()
         else:
             input_sample_set._values = None
+
         comm.barrier()
 
         discretization = sample.discretization(input_sample_set,
@@ -439,7 +445,9 @@ class sampler(object):
 
         if savefile is not None:
             self.save(mdat, savefile, discretization, globalize=globalize)
+
         comm.barrier()
+
         return discretization
 
     def create_random_discretization(self, sample_type, input_obj,

--- a/bet/sampling/basicSampling.py
+++ b/bet/sampling/basicSampling.py
@@ -404,7 +404,7 @@ class sampler(object):
 
         output_sample_set = sample.sample_set(output_dim)
         output_sample_set.set_values_local(local_output_values)
-        lam_ref = input_sample_set._reference_value 
+        lam_ref = input_sample_set._reference_value
 
         if lam_ref is not None:
             try:
@@ -417,7 +417,7 @@ class sampler(object):
                     msg = "Model not mapping reference value as expected."
                     msg += "Attempting reshape..."
                     logging.log(20, msg)
-                    Q_ref = self.lb_model(lam_ref.reshape(-1,1))
+                    Q_ref = self.lb_model(lam_ref.reshape(-1, 1))
                     output_sample_set.set_reference_value(Q_ref)
                 except ValueError:
                     logging.log(20, 'Unable to map reference value.')

--- a/bet/sampling/basicSampling.py
+++ b/bet/sampling/basicSampling.py
@@ -417,7 +417,7 @@ class sampler(object):
                     msg = "Model not mapping reference value as expected."
                     msg += "Attempting reshape..."
                     logging.log(20, msg)
-                    Q_ref = self.lb_model(lam_ref.reshape(-1, 1))
+                    Q_ref = self.lb_model(lam_ref.reshape(1, -1))
                     output_sample_set.set_reference_value(Q_ref)
                 except ValueError:
                     logging.log(20, 'Unable to map reference value.')

--- a/bet/sampling/basicSampling.py
+++ b/bet/sampling/basicSampling.py
@@ -377,6 +377,7 @@ class sampler(object):
         # Solve the model at the samples
         if input_sample_set._values_local is None:
             input_sample_set.global_to_local()
+
         local_output = self.lb_model(
             input_sample_set.get_values_local())
         if isinstance(local_output, np.ndarray):
@@ -401,6 +402,22 @@ class sampler(object):
             output_dim = local_output_values.shape[1]
         output_sample_set = sample.sample_set(output_dim)
         output_sample_set.set_values_local(local_output_values)
+        lam_ref = input_sample_set._reference_value 
+        if lam_ref is not None:
+            try:
+                if not isinstance(lam_ref, collections.Iterable):
+                    lam_ref = np.array([lam_ref])
+                Q_ref = self.lb_model(lam_ref)
+                output_sample_set.set_reference_value(Q_ref)
+            except ValueError:
+                try:
+                    msg = "Model not mapping reference value as expected."
+                    msg += "Attempting reshape..."
+                    logging.log(20, msg)
+                    Q_ref = self.lb_model(lam_ref.reshape(-1,1))
+                    output_sample_set.set_reference_value(Q_ref)
+                except ValueError:
+                    logging.log(20, 'Unable to map reference value.')
         if self.error_estimates:
             output_sample_set.set_error_estimates_local(local_output_ee)
         if self.jacobians:

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ImportError:
     from distutils.core import setup
 
 setup(name='bet',
-      version='2.1.1',
+      version='2.1.2',
       description='Butler, Estep, Tavener method',
       author='Steven Mattis',
       author_email='steve.a.mattis@gmail.com',


### PR DESCRIPTION
this pull request adds a single feature to the codebase: setting `Q_ref` when `lam_ref` is provided as the `reference_value` attribute of `input_sample_set` within a discretization object. This frees up the keyword arguments to take on some default values in `simpleFunP` and sets the stage for future changes to simplify problem definition and solution. 
