### PR TITLE
resiliency to overwriting output_probability_set

### DIFF
--- a/bet/calculateP/simpleFunP.py
+++ b/bet/calculateP/simpleFunP.py
@@ -21,6 +21,10 @@ class wrong_argument_type(Exception):
 
 
 def check_type(val, data_set=None):
+    """
+    Add support for different data types that can be passed as keyword
+    arguments. Attempt to infer dimension and set it correctly.
+    """
     if isinstance(data_set, samp.discretization):
         dim = data_set._output_sample_set.get_dim()
     elif isinstance(data_set, samp.sample_set_base):
@@ -42,6 +46,9 @@ def check_type(val, data_set=None):
 
 
 def infer_Q(data_set):
+    """
+    Attempt to infer reference value around which to define a sample set.
+    """
     if isinstance(data_set, samp.sample_set_base):
         return data_set.get_reference_value()
     elif isinstance(data_set, samp.discretization):

--- a/bet/calculateP/simpleFunP.py
+++ b/bet/calculateP/simpleFunP.py
@@ -20,6 +20,36 @@ class wrong_argument_type(Exception):
     """
 
 
+def check_type(val, data_set=None):
+    if isinstance(data_set, samp.discretization):
+        dim = data_set._output_sample_set.get_dim()
+    elif isinstance(data_set, samp.sample_set_base):
+        dim = data_set.get_dim()
+    else:
+        dim = 1
+    if isinstance(val, float) or isinstance(val, int):
+        val = np.array([val]*dim)
+    elif isinstance(val, list) or isinstance(val, tuple):
+        if len(val) != dim:
+            raise samp.dim_not_matching("Dimension mismatch.")
+        else:
+            val = np.array(val)
+    elif not isinstance(val, collections.Iterable):
+        val = np.array([val])
+    else:
+        pass
+    return val
+
+
+def infer_Q(data_set):
+    if isinstance(data_set, samp.sample_set_base):
+        return data_set.get_reference_value()
+    elif isinstance(data_set, samp.discretization):
+        return data_set._output_sample_set.get_reference_value()
+    else:
+        return None
+
+
 def check_inputs(data_set, Q_ref):
     """
     Checks inputs to methods.
@@ -129,7 +159,8 @@ def uniform_partition_uniform_distribution_rectangle_size(data_set,
     :rtype: :class:`~bet.sample.voronoi_sample_set`
     :returns: sample_set object defininng simple function approximation
     """
-
+    if Q_ref is None:
+        Q_ref = infer_Q(data_set)
     (num, dim, values, Q_ref) = check_inputs(data_set, Q_ref)
 
     if rect_size is None:
@@ -212,6 +243,7 @@ def uniform_partition_uniform_distribution_rectangle_size(data_set,
     '''
     if isinstance(data_set, samp.discretization):
         data_set._output_probability_set = s_set
+        data_set.set_io_ptr(globalize=False)
     return s_set
 
 
@@ -259,6 +291,8 @@ def uniform_partition_uniform_distribution_rectangle_scaled(data_set,
     :rtype: :class:`~bet.sample.voronoi_sample_set`
     :returns: sample_set object defininng simple function approximation
     """
+    if Q_ref is None:
+        Q_ref = infer_Q(data_set)
     (num, dim, values, Q_ref) = check_inputs(data_set, Q_ref)
     rect_size = (np.max(values, 0) - np.min(values, 0))*rect_scale
 
@@ -341,6 +375,8 @@ def regular_partition_uniform_distribution_rectangle_size(data_set, Q_ref=None,
     :returns: sample_set object defining simple function approximation
 
     """
+    if Q_ref is None:
+        Q_ref = infer_Q(data_set)
     (num, dim, values, Q_ref) = check_inputs(data_set, Q_ref)
 
     data = values
@@ -378,6 +414,7 @@ def regular_partition_uniform_distribution_rectangle_size(data_set, Q_ref=None,
 
     if isinstance(data_set, samp.discretization):
         data_set._output_probability_set = s_set
+        data_set.set_io_ptr(globalize=False)
     return s_set
 
 
@@ -420,8 +457,9 @@ def regular_partition_uniform_distribution_rectangle_domain(data_set,
                                                                  cells_per_dimension)
 
 
-def regular_partition_uniform_distribution_rectangle_scaled(data_set, Q_ref,
-                                                            rect_scale,
+def regular_partition_uniform_distribution_rectangle_scaled(data_set,
+                                                            Q_ref=None,
+                                                            rect_scale=1,
                                                             cells_per_dimension=1):
     r"""
     Creates a simple function approximation of :math:`\rho_{\mathcal{D},M}`
@@ -439,7 +477,7 @@ def regular_partition_uniform_distribution_rectangle_scaled(data_set, Q_ref,
     :type data_set: :class:`~bet.sample.discretization` or
         :class:`~bet.sample.sample_set` or :class:`~numpy.ndarray`
     :param rect_scale: The scale used to determine the width of the
-        uniform distributiion as ``rect_size = (data_max-data_min)*rect_scale``
+        uniform distribution as ``rect_size = (data_max-data_min)*rect_scale``
     :type rect_scale: double or list
     :param Q_ref: :math:`Q(\lambda_{reference})`
     :type Q_ref: :class:`~numpy.ndarray` of size (mdim,)
@@ -449,6 +487,8 @@ def regular_partition_uniform_distribution_rectangle_scaled(data_set, Q_ref,
     :returns: sample_set object defining simple function approximation
 
     """
+    if Q_ref is None:
+        Q_ref = infer_Q(data_set)
     (num, dim, values, Q_ref) = check_inputs(data_set, Q_ref)
 
     data = values
@@ -505,10 +545,11 @@ def uniform_partition_uniform_distribution_data_samples(data_set):
 
     if isinstance(data_set, samp.discretization):
         data_set._output_probability_set = s_set
+        data_set.set_io_ptr(globalize=False)
     return s_set
 
 
-def normal_partition_normal_distribution(data_set, Q_ref, std, M,
+def normal_partition_normal_distribution(data_set, Q_ref=None, std=1, M=1,
                                          num_d_emulate=1E6):
     r"""
     Creates a simple function approximation of :math:`\rho_{\mathcal{D},M}`
@@ -534,14 +575,14 @@ def normal_partition_normal_distribution(data_set, Q_ref, std, M,
     :returns: sample_set object defining simple function approximation
 
     """
+    if Q_ref is None:
+        Q_ref = infer_Q(data_set)
     import scipy.stats as stats
     r'''Create M smaples defining M bins in D used to define
     :math:`\rho_{\mathcal{D},M}` rho_D is assumed to be a multi-variate normal
     distribution with mean Q_ref and standard deviation std.'''
-    if not isinstance(Q_ref, collections.Iterable):
-        Q_ref = np.array([Q_ref])
-    if not isinstance(std, collections.Iterable):
-        std = np.array([std])
+    Q_ref = check_type(Q_ref, data_set)
+    std = check_type(std, data_set)
 
     covariance = std ** 2
 
@@ -601,10 +642,11 @@ def normal_partition_normal_distribution(data_set, Q_ref, std, M,
     # solving the model EVER! This can be done "offline" so to speak.
     if isinstance(data_set, samp.discretization):
         data_set._output_probability_set = s_set
+        data_set.set_io_ptr(globalize=False)
     return s_set
 
 
-def uniform_partition_normal_distribution(data_set, Q_ref, std, M,
+def uniform_partition_normal_distribution(data_set, Q_ref=None, std=1, M=1,
                                           num_d_emulate=1E6):
     r"""
     Creates a simple function approximation of :math:`\rho_{\mathcal{D},M}`
@@ -634,10 +676,10 @@ def uniform_partition_normal_distribution(data_set, Q_ref, std, M,
     r'''Create M samples defining M bins in D used to define
     :math:`\rho_{\mathcal{D},M}` rho_D is assumed to be a multi-variate normal
     distribution with mean Q_ref and standard deviation std.'''
-    if not isinstance(Q_ref, collections.Iterable):
-        Q_ref = np.array([Q_ref])
-    if not isinstance(std, collections.Iterable):
-        std = np.array([std])
+    if Q_ref is None:
+        Q_ref = infer_Q(data_set)
+    Q_ref = check_type(Q_ref, data_set)
+    std = check_type(std, data_set)
 
     bin_size = 4.0 * std
     d_distr_samples = np.zeros((M, len(Q_ref)))
@@ -685,6 +727,7 @@ def uniform_partition_normal_distribution(data_set, Q_ref, std, M,
     # solving the model EVER! This can be done "offline" so to speak.
     if isinstance(data_set, samp.discretization):
         data_set._output_probability_set = s_set
+        data_set.set_io_ptr(globalize=False)
     return s_set
 
 
@@ -791,4 +834,5 @@ def user_partition_user_distribution(data_set, data_partition_set,
 
     if isinstance(data_set, samp.discretization):
         data_set._output_probability_set = s_set
+        data_set.set_io_ptr(globalize=False)
     return s_set

--- a/bet/sample.py
+++ b/bet/sample.py
@@ -2486,7 +2486,7 @@ class discretization(object):
                 raise dim_not_matching("dimension of values incorrect")
         else:
             raise AttributeError("Wrong Type: Should be sample_set_base type")
-        if self._input_sample_set is not None:
+        if self._output_sample_set._values_local is not None:
             self.set_io_ptr(globalize=False)
 
     def get_emulated_output_sample_set(self):

--- a/bet/sample.py
+++ b/bet/sample.py
@@ -2486,6 +2486,8 @@ class discretization(object):
                 raise dim_not_matching("dimension of values incorrect")
         else:
             raise AttributeError("Wrong Type: Should be sample_set_base type")
+        if self._input_sample_set is not None:
+            self.set_io_ptr(globalize=False)
 
     def get_emulated_output_sample_set(self):
         """


### PR DESCRIPTION
this PR addresses unexpected behavior wherein if a user overwrites `output_probability_measure` using simpleFunP AFTER having already run `calculateP.prob`, the answers returned are complete nonsense and do not reflect changes made to the measure on the data space. 

The underlying problem was that `set_io_ptr` was called the first time, but not on successive over-writings of the output_probabilities. 

Now, `set_io_ptr` is called inside of simpleFunP, so the default is that `prob` does not perform computations of pointers. this may slightly lower coverage for that module as a result. The function `set_output_probability_set` in `discretization` ~~should also~~ will do the same, ~~but currently that is not included herein.~~ 

Also allowing for "smarter behavior" by being able to infer the reference data and more types of keyword arguments. All tests pass, though coverage decreases a tiny amount. 