### PR TITLE
version-lock scipy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ before_install:
   - sudo apt-get install gfortran libblas-dev liblapack-dev mpich libmpich-dev
 
 install:
-  - pip install numpy scipy matplotlib pyDOE mpi4py nose codecov
+  - pip install numpy scipy==1.2.1 matplotlib pyDOE mpi4py nose codecov
   - python setup.py install
 
 script:

--- a/setup.py
+++ b/setup.py
@@ -19,5 +19,5 @@ setup(name='bet',
       url='https://github.com/UT-CHG/BET',
       packages=['bet', 'bet.sampling', 'bet.calculateP', 
                 'bet.postProcess', 'bet.sensitivity'],
-      install_requires=['matplotlib', 'pyDOE', 'scipy',
+      install_requires=['matplotlib', 'pyDOE', 'scipy<=1.2.1',
                         'numpy', 'nose'])


### PR DESCRIPTION
addresses #335 until we can figure out what in the [1.3.0 Release Notes](https://docs.scipy.org/doc/scipy/reference/release.1.3.0.html) that is causing `adaptiveSampling` to fail.