### PR TITLE
fix typo in docs.

### DIFF
--- a/bet/calculateP/calculateP.py
+++ b/bet/calculateP/calculateP.py
@@ -26,7 +26,7 @@ def prob_on_emulated_samples(discretization, globalize=True):
     r"""
 
     Calculates :math:`P_{\Lambda}(\mathcal{V}_{\lambda_{emulate}})`, the
-    probability assoicated with a set of voronoi cells defined by
+    probability associated with a set of voronoi cells defined by
     ``num_l_emulate`` iid samples :math:`(\lambda_{emulate})`.
     This is added to the emulated input sample set object.
 
@@ -70,7 +70,7 @@ def prob_on_emulated_samples(discretization, globalize=True):
 def prob(discretization, globalize=True):
     r"""
     Calculates :math:`P_{\Lambda}(\mathcal{V}_{\lambda_{samples}})`, the
-    probability assoicated with a set of  cells defined by the model
+    probability associated with a set of  cells defined by the model
     solves at :math:`(\lambda_{samples})` where the volumes of these
     cells are provided.
 

--- a/bet/calculateP/simpleFunP.py
+++ b/bet/calculateP/simpleFunP.py
@@ -585,7 +585,7 @@ def normal_partition_normal_distribution(data_set, Q_ref=None, std=1, M=1,
     if Q_ref is None:
         Q_ref = infer_Q(data_set)
     import scipy.stats as stats
-    r'''Create M smaples defining M bins in D used to define
+    r'''Create M samples defining M bins in D used to define
     :math:`\rho_{\mathcal{D},M}` rho_D is assumed to be a multi-variate normal
     distribution with mean Q_ref and standard deviation std.'''
     Q_ref = check_type(Q_ref, data_set)

--- a/bet/sampling/basicSampling.py
+++ b/bet/sampling/basicSampling.py
@@ -361,7 +361,7 @@ class sampler(object):
 
         :param input_sample_set: samples to evaluate the model at
         :type input_sample_set: :class:`~bet.sample.sample_set` with
-            num_smaples
+            num_samples
         :param string savefile: filename to save samples and data
         :param bool globalize: Makes local variables global.
 

--- a/examples/FEniCS/BET_multiple_serial_models_script.py
+++ b/examples/FEniCS/BET_multiple_serial_models_script.py
@@ -125,7 +125,7 @@ else:
         data_set=my_discretization, Q_ref=Q_ref[0, :], rect_scale=0.1,
         M=50, num_d_emulate=1E5)
 
-# calculate probablities
+# calculate probabilities
 calculateP.prob(my_discretization)
 
 ########################################

--- a/examples/FEniCS/BET_script.py
+++ b/examples/FEniCS/BET_script.py
@@ -124,7 +124,7 @@ else:
         data_set=my_discretization, Q_ref=Q_ref[0, :], rect_scale=0.1,
         M=50, num_d_emulate=1E5)
 
-# calculate probablities
+# calculate probabilities
 calculateP.prob(my_discretization)
 
 ########################################

--- a/examples/contaminantTransport/contaminant.ipynb
+++ b/examples/contaminantTransport/contaminant.ipynb
@@ -223,7 +223,7 @@
     "                                                                     rect_scale=0.25,\n",
     "                                                                     M=50,\n",
     "                                                                     num_d_emulate=1E5)\n",
-    "# calculate probablities making Monte Carlo assumption\n",
+    "# calculate probabilities making Monte Carlo assumption\n",
     "calculateP.prob(my_discretization)"
    ]
   },

--- a/examples/contaminantTransport/contaminant.py
+++ b/examples/contaminantTransport/contaminant.py
@@ -82,7 +82,7 @@ else:
                                                                        M=50,
                                                                        num_d_emulate=1E5)
 
-# calculate probablities making Monte Carlo assumption
+# calculate probabilities making Monte Carlo assumption
 calculateP.prob(my_discretization)
 
 # calculate 2D marginal probabilities

--- a/examples/linearMap/linearMapUniformSampling.ipynb
+++ b/examples/linearMap/linearMapUniformSampling.ipynb
@@ -206,7 +206,7 @@
     "        data_set=my_discretization, Q_ref=Q_ref, rect_scale=0.25,\n",
     "        M=50, num_d_emulate=1E5)\n",
     "\n",
-    "# calculate probablities\n",
+    "# calculate probabilities\n",
     "calculateP.prob(my_discretization)"
    ]
   },

--- a/examples/linearMap/linearMapUniformSampling.py
+++ b/examples/linearMap/linearMapUniformSampling.py
@@ -131,7 +131,7 @@ else:
         data_set=my_discretization, Q_ref=Q_ref, rect_scale=0.25,
         M=50, num_d_emulate=1E5)
 
-# calculate probablities
+# calculate probabilities
 calculateP.prob(my_discretization)
 
 ########################################

--- a/examples/nonlinearMap/nonlinearMapUniformSampling.py
+++ b/examples/nonlinearMap/nonlinearMapUniformSampling.py
@@ -132,7 +132,7 @@ else:
         data_set=my_discretization, Q_ref=Q_ref, rect_scale=0.25,
         M=50, num_d_emulate=1E5)
 
-# calculate probablities
+# calculate probabilities
 calculateP.prob(my_discretization)
 
 ########################################

--- a/examples/sensitivity/linear/linear_measure_binsize_large.py
+++ b/examples/sensitivity/linear/linear_measure_binsize_large.py
@@ -117,7 +117,7 @@ simpleFunP.regular_partition_uniform_distribution_rectangle_scaled(
     data_set=my_discretization, Q_ref=Q_ref, rect_scale=bin_ratio,
     cells_per_dimension=1)
 
-# Calculate probablities making the Monte Carlo assumption
+# Calculate probabilities making the Monte Carlo assumption
 calculateP.prob(my_discretization)
 
 percentile = 1.0

--- a/examples/sensitivity/linear/linear_skewness_binratio.py
+++ b/examples/sensitivity/linear/linear_skewness_binratio.py
@@ -110,7 +110,7 @@ simpleFunP.regular_partition_uniform_distribution_rectangle_scaled(
     data_set=my_discretization, Q_ref=Q_ref, rect_scale=bin_ratio,
     cells_per_dimension=1)
 
-# Calculate probablities making the Monte Carlo assumption
+# Calculate probabilities making the Monte Carlo assumption
 calculateP.prob(my_discretization)
 
 percentile = 1.0

--- a/examples/sensitivity/linear_sensitivity.ipynb
+++ b/examples/sensitivity/linear_sensitivity.ipynb
@@ -117,7 +117,7 @@
     "            cells_per_dimension=1)\n",
     "    \n",
     "    \n",
-    "    # Calculate probablities making the Monte Carlo assumption\n",
+    "    # Calculate probabilities making the Monte Carlo assumption\n",
     "    calculateP.prob(my_discretization)\n",
     "    \n",
     "    # Sort samples by highest probability density and find how many samples lie in\n",


### PR DESCRIPTION
addressing #342, replaced one-at-a-time with fuzzy-finder and sed, only handling the typos I mentioned in that issue. may be others around. docs still need to be rebuilt to reflect changes.