### PR TITLE
Sample-based methods

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -12,5 +12,7 @@ build/
 *.eps
 *.mat
 *.swp
+*.swo
+*.swn
 dist/
 bet.egg-info/

--- a/.hound.yml
+++ b/.hound.yml
@@ -1,0 +1,2 @@
+flake8:
+  enabled: true

--- a/.travis.yml
+++ b/.travis.yml
@@ -2,9 +2,10 @@ dist: xenial
 language: python
 
 python:
-    - "2.7"
+    - "3.5"
     - "3.6"
     - "3.7"
+    - "3.8"
 
 services:
   - xvfb
@@ -21,15 +22,13 @@ script:
   - nosetests --with-coverage --cover-package=bet --cover-erase --cover-html
   - mpirun -n 2 nosetests
   - pip uninstall -y mpi4py
+  - rm proc* && rm test/test_sampling/testfile*
   - nosetests
 
 # notification settings
 notifications:
     email:
         recipients:
-            - steve.a.mattis@gmail.com
-            - lichgraham@gmail.com
-            - scottw13@gmail.com
             - michael.pilosov@ucdenver.edu
         on_success: change
         on_failure: always
@@ -38,6 +37,8 @@ notifications:
 branches:
     only:
         - master
+        - sample
+        - develop
 
 # Push the results back to codecov
 after_success:

--- a/bet/calculateP/simpleFunP.py
+++ b/bet/calculateP/simpleFunP.py
@@ -221,8 +221,8 @@ def uniform_partition_uniform_distribution_rectangle_size(data_set,
     :math:`\rho_{\mathcal{D}}`.
     '''
     # Generate the samples from :math:`\rho_{\mathcal{D}}`
-    num_d_emulate_local = int((num_d_emulate / comm.size) +
-                              (comm.rank < num_d_emulate % comm.size))
+    num_d_emulate_local = int(num_d_emulate / comm.size) + \
+        int(comm.rank < num_d_emulate % comm.size)
     d_distr_emulate = rect_size * (np.random.random((num_d_emulate_local,
                                                      dim)) - 0.5) + Q_ref
 
@@ -397,7 +397,7 @@ def regular_partition_uniform_distribution_rectangle_size(data_set, Q_ref=None,
         raise wrong_argument_type(msg)
 
     if not isinstance(cells_per_dimension, collections.Iterable):
-        cells_per_dimension = np.ones((dim,)) * cells_per_dimension
+        cells_per_dimension = np.ones((dim,)).astype(int) * cells_per_dimension
 
     maxes = [Q_ref + 0.5 * np.array(rect_size)]
     mins = [Q_ref - 0.5 * np.array(rect_size)]
@@ -611,8 +611,8 @@ def normal_partition_normal_distribution(data_set, Q_ref=None, std=1, M=1,
     r'''Now compute probabilities for :math:`\rho_{\mathcal{D},M}` by sampling
     from rho_D First generate samples of rho_D - I sometimes call this
     emulation'''
-    num_d_emulate_local = int((num_d_emulate / comm.size) +
-                              (comm.rank < num_d_emulate % comm.size))
+    num_d_emulate_local = int(num_d_emulate / comm.size) + \
+        int(comm.rank < num_d_emulate % comm.size)
     d_distr_emulate = np.zeros((num_d_emulate_local, len(Q_ref)))
     for i in range(len(Q_ref)):
         d_distr_emulate[:, i] = np.random.normal(Q_ref[i], std[i],
@@ -703,8 +703,8 @@ def uniform_partition_normal_distribution(data_set, Q_ref=None, std=1, M=1,
     r'''Now compute probabilities for :math:`\rho_{\mathcal{D},M}` by sampling
     from rho_D First generate samples of rho_D - I sometimes call this
     emulation'''
-    num_d_emulate_local = int((num_d_emulate / comm.size) +
-                              (comm.rank < num_d_emulate % comm.size))
+    num_d_emulate_local = int(num_d_emulate / comm.size) + \
+        int(comm.rank < num_d_emulate % comm.size)
     d_distr_emulate = np.zeros((num_d_emulate_local, len(Q_ref)))
     for i in range(len(Q_ref)):
         d_distr_emulate[:, i] = np.random.normal(Q_ref[i], std[i],

--- a/bet/postProcess/compareP.py
+++ b/bet/postProcess/compareP.py
@@ -126,14 +126,14 @@ class comparison(object):
         self._comparison_sample_set = comparison_sample_set
         #: Pointer from ``self._comparison_sample_set`` to
         #: ``self._left_sample_set``
-        self._ptr_left = ptr_left
+        self._ptr_left = None
         #: Pointer from ``self._comparison_sample_set`` to
         #: ``self._right_sample_set``
-        self._ptr_right = ptr_right
+        self._ptr_right = None
         #: local integration left ptr for parallelsim
-        self._ptr_left_local = None
+        self._ptr_left_local = ptr_left
         #: local integration right ptr for parallelism
-        self._ptr_right_local = None
+        self._ptr_right_local = ptr_right
         #: Domain
         self._domain = None
         #: Left sample set density evaluated on emulation set.
@@ -195,6 +195,8 @@ class comparison(object):
             if len(ptr_left) != self._num_samples:
                 raise AttributeError(
                     "Left pointer length must match comparison set.")
+            else:
+                self._ptr_left_local = ptr_left
             if (ptr_right is not None):
                 if not np.allclose(ptr_left.shape, ptr_right.shape):
                     raise AttributeError("Pointers must be of same length.")
@@ -202,6 +204,8 @@ class comparison(object):
             if len(ptr_right) != self._num_samples:
                 raise AttributeError(
                     "Right pointer length must match comparison set.")
+            else:
+                self._ptr_right_local = ptr_right
 
     def check_dim(self):
         r"""
@@ -675,7 +679,8 @@ class comparison(object):
         comp = comparison(sample_set_left=left_ss,
                           sample_set_right=right_ss,
                           comparison_sample_set=comp_ss)
-        # additional attributes to copy over here. TODO: maybe slice through
+        # additional attributes to copy over here.
+        # maybe "setup"?
         return comp
 
     def global_to_local(self):

--- a/bet/sample.py
+++ b/bet/sample.py
@@ -16,13 +16,12 @@ import numpy as np
 import math as math
 import numpy.linalg as linalg
 import scipy.spatial as spatial
-import scipy.io as sio
 import scipy.stats
 import bet
 from bet.Comm import comm, MPI
 import bet.util as util
 import bet.sampling.LpGeneralizedSamples as lp
-
+import pickle
 
 class length_not_matching(Exception):
     """
@@ -46,6 +45,26 @@ class wrong_p_norm(Exception):
     """
     Exception for when the dimension of the array is inconsistent.
     """
+
+
+def loadmat(filename):
+    """
+    Replacement for sio.loadmat
+    """
+    try:
+        with open(filename, 'rb') as input_file:
+            mdat = pickle.load(input_file)  # , encoding='utf-8')
+    except EOFError:
+        mdat = {}
+    return mdat
+
+
+def savemat(filename, data):
+    """
+    Replacement for sio.loadmat
+    """
+    with open(filename, 'wb') as output_file:
+        pickle.dump(data, output_file)
 
 
 def save_sample_set(save_set, file_name,
@@ -72,7 +91,8 @@ def save_sample_set(save_set, file_name,
     if comm.size > 1 and not globalize:
         local_file_name = os.path.join(os.path.dirname(file_name),
                                        "proc{}_{}".format(comm.rank,
-                                                          os.path.basename(file_name)))
+                                                          os.path.
+                                                          basename(file_name)))
     else:
         local_file_name = file_name
 
@@ -85,7 +105,7 @@ def save_sample_set(save_set, file_name,
     # create temporary dictionary
     if os.path.exists(local_file_name) or \
             os.path.exists(local_file_name + '.mat'):
-        new_mdat = sio.loadmat(local_file_name)
+        new_mdat = loadmat(local_file_name)
 
     # store sample set in dictionary
     if sample_set_name is None:
@@ -104,11 +124,21 @@ def save_sample_set(save_set, file_name,
             new_mdat.pop(sample_set_name + attrname)
     new_mdat[sample_set_name + '_sample_set_type'] = \
         str(type(save_set)).split("'")[1]
+    dist = save_set.get_dist()
+    if dist is not None:
+        kwds = dist.kwds
+        for kwd in kwds.keys():
+            new_mdat[sample_set_name + '_dist_kwds_' + kwd] = \
+                kwds[kwd]
+            print('saved %s' % kwd)
+        new_mdat[sample_set_name + '_dist_type'] = \
+            str(save_set.get_dist().dist).split(' ')[0].replace(
+                '<', '').replace('_gen', '').replace('_continuous_distns.', '')
     comm.barrier()
 
     # save new file or append to existing file
     if (globalize and comm.rank == 0) or not globalize:
-        sio.savemat(local_file_name, new_mdat)
+        savemat(local_file_name, new_mdat)
     comm.barrier()
     return local_file_name
 
@@ -136,17 +166,29 @@ def load_sample_set(file_name, sample_set_name=None, localize=True):
     if file_name.startswith('proc_'):
         localize = False
     elif not os.path.exists(file_name) and os.path.exists(os.path.join(
-            os.path.dirname(file_name), "proc{}_0".format(
+            os.path.dirname(file_name), "proc0_{}".format(
                 os.path.basename(file_name)))):
         return load_sample_set_parallel(file_name, sample_set_name)
 
-    mdat = sio.loadmat(file_name)
+    mdat = loadmat(file_name)
     if sample_set_name is None:
         sample_set_name = 'default'
+    mdat_keys = list(mdat.keys())
+    if sample_set_name + "_dim" in mdat_keys:
+        loaded_set = eval(mdat[sample_set_name + '_sample_set_type'])(
+            np.int(np.squeeze(mdat[sample_set_name + "_dim"])))
+        if sample_set_name + '_dist_type' in mdat_keys:
+            kwds = {}
+            # extract keywords from mdat
+            kwd_keys = [k for k in mdat_keys if 'kwds' in k]
+            # build dictionary
+            for key in kwd_keys:
+                newkey = key.replace('dist_kwds', '').replace(
+                    sample_set_name, '').replace('_', '')
+                kwds[newkey] = mdat[key]
+            dist = eval(mdat[sample_set_name + '_dist_type'])(**kwds)
+            loaded_set.set_distribution(dist)
 
-    if sample_set_name + "_dim" in list(mdat.keys()):
-        loaded_set = eval(mdat[sample_set_name + '_sample_set_type'][0])(
-            np.squeeze(mdat[sample_set_name + "_dim"]))
     else:
         logging.info("No sample_set named {} with _dim in file".
                      format(sample_set_name))
@@ -154,11 +196,11 @@ def load_sample_set(file_name, sample_set_name=None, localize=True):
 
     for attrname in loaded_set.vector_names:
         if attrname is not '_dim':
-            if sample_set_name + attrname in list(mdat.keys()):
+            if sample_set_name + attrname in mdat_keys:
                 setattr(loaded_set, attrname,
                         np.squeeze(mdat[sample_set_name + attrname]))
     for attrname in loaded_set.all_ndarray_names:
-        if sample_set_name + attrname in list(mdat.keys()):
+        if sample_set_name + attrname in mdat_keys:
             setattr(loaded_set, attrname, mdat[sample_set_name + attrname])
 
     if localize:
@@ -210,27 +252,47 @@ def load_sample_set_parallel(file_name, sample_set_name=None):
         # Determine how many processors the previous data used
         # otherwise gather the data from mdat and then scatter
         # among the processors and update mdat
-        mdat_files_local = comm.scatter(mdat_files)
-        mdat_local = [sio.loadmat(m) for m in mdat_files_local]
-        mdat_list = comm.allgather(mdat_local)
+        try:
+            mdat_files_local = comm.scatter(mdat_files)
+            mdat_local = [loadmat(m) for m in mdat_files_local]
+            mdat_list = comm.allgather(mdat_local)
+        except ValueError:
+            mdat_files_local = mdat_files
+            mdat_local = [loadmat(m) for m in mdat_files_local]
+            mdat_list = mdat_local
         mdat_global = []
         # instead of a list of lists, create a list of mdat
         for mlist in mdat_list:
-            mdat_global.extend(mlist)
+            mdat_global.append(mlist)
 
-        if sample_set_name + "_dim" in list(mdat_global[0].keys()):
+        # set attributes that are not vectors (distributions)
+        mdat_keys = list(mdat_global[0].keys())
+        if sample_set_name + "_dim" in mdat_keys:
             loaded_set = eval(mdat_global[0][sample_set_name +
-                                             '_sample_set_type'][0])(
-                np.squeeze(mdat_global[0][sample_set_name + "_dim"]))
+                                             '_sample_set_type'])(
+                np.int(np.squeeze(mdat_global[0][sample_set_name + "_dim"])))
         else:
             logging.info("No sample_set named {} with _dim in file".
                          format(sample_set_name))
             return None
 
+        if sample_set_name + '_dist_type' in mdat_keys:
+            kwds = {}
+            # extract keywords from mdat
+            kwd_keys = [k for k in mdat_keys if 'kwds' in k]
+            # build dictionary
+            for key in kwd_keys:
+                newkey = key.replace('dist_kwds', '').replace(
+                    sample_set_name, '').replace('_', '')
+                kwds[newkey] = mdat_global[0][key]
+            dist = eval(
+                mdat_global[0][sample_set_name + '_dist_type'])(**kwds)
+            loaded_set.set_distribution(dist)
+
         # load attributes
         for attrname in loaded_set.vector_names:
             if attrname is not '_dim':
-                if sample_set_name + attrname in list(mdat_global[0].keys()):
+                if sample_set_name + attrname in mdat_keys:
                     # create lists of local data
                     if attrname.endswith('_local'):
                         temp_input = []
@@ -244,7 +306,7 @@ def load_sample_set_parallel(file_name, sample_set_name=None):
                                                 [sample_set_name + attrname])
                     setattr(loaded_set, attrname, temp_input)
         for attrname in loaded_set.all_ndarray_names:
-            if sample_set_name + attrname in list(mdat_global[0].keys()):
+            if sample_set_name + attrname in mdat_keys:
                 if attrname.endswith('_local'):
                     # create lists of local data
                     temp_input = []
@@ -258,6 +320,7 @@ def load_sample_set_parallel(file_name, sample_set_name=None):
 
         # re-localize if necessary
         loaded_set.local_to_global()
+        return loaded_set
 
 
 class sample_set_base(object):
@@ -306,6 +369,10 @@ class sample_set_base(object):
         self._values = None
         #: :class:`numpy.ndarray` of sample Voronoi volumes of shape (num,)
         self._volumes = None
+        #: :class:`scipy.stats.distributions.rv_frozen` describing distribution
+        self._distribution = None
+        #: :class:`numpy.ndarray` of sample densities of shape (num,)
+        self._densities = None
         #: :class:`numpy.ndarray` of sample probabilities of shape (num,)
         self._probabilities = None
         #: :class:`numpy.ndarray` of sample densities of shape (num,)
@@ -316,9 +383,10 @@ class sample_set_base(object):
         #: :class:`numpy.ndarray` of model error estimates at samples of shape
         #: (num, dim)
         self._error_estimates = None
-        #: The sample domain :class:`numpy.ndarray` of shape (dim, 2)
+        #: The sample domain, :class:`numpy.ndarray` of shape (dim, 2)
         self._domain = None
-        #: The sample domain before normalization :class:`numpy.ndarray` of shape (dim, 2)
+        #: The sample domain pre-normalization,
+        #: :class:`numpy.ndarray` of shape (dim, 2)
         self._domain_original = None
         #: Bounding box of values, :class:`numpy.ndarray`of shape (dim, 2)
         self._bounding_box = None
@@ -591,8 +659,8 @@ class sample_set_base(object):
         :param values: values to append
         :type values: :class:`numpy.ndarray` of shape (some_num, dim)
         """
-        self._values = np.concatenate((self._values,
-                                       util.fix_dimensions_data(values, self._dim)), 0)
+        vl = util.fix_dimensions_data(values, self._dim)
+        self._values = np.concatenate((self._values, vl), 0)
 
     def append_values_local(self, values_local):
         """
@@ -605,15 +673,47 @@ class sample_set_base(object):
         :param values_local: values to append
         :type values_local: :class:`numpy.ndarray` of shape (some_num, dim)
         """
-        self._values_local = np.concatenate((self._values_local,
-                                             util.fix_dimensions_data(values_local, self._dim)), 0)
+        vl = util.fix_dimensions_data(values_local, self._dim)
+        self._values_local = np.concatenate((self._values_local, vl), 0)
 
     def clip(self, cnum):
         """
         Creates and returns a sample set with the the first `cnum`
+        entries of the sample set if `cnum` is an integer.
+        If `cum` is a list, it is used to return a selection of rows.
+
+        :param cnum: number/selection of values of sample set to return
+        :type cnum: `int` or iterable indices into rows of sample set.
+
+        :rtype: :class:`~bet.sample.sample_set`
+        :returns: the clipped sample set
+
+        """
+        sset = self.copy()
+        sset.check_num()
+        if isinstance(cnum, int):
+            indices = list(np.arange(cnum))
+        elif isinstance(cnum, list) or isinstance(cnum, tuple):
+            indices = cnum
+
+        if sset._values is None:
+            sset.local_to_global()
+        for array_name in self.array_names:
+            current_array = getattr(sset, array_name)
+            if current_array is not None:
+                new_array = current_array[indices]
+                setattr(sset, array_name, new_array)
+        if sset._values_local is not None:
+            sset.global_to_local()
+        sset.set_kdtree()
+        return sset
+
+    def clip_samples(self, inds):
+        """
+        Creates and returns a sample set with the the first `cnum`
         entries of the sample set.
 
-        :param int cnum: number of values of sample set to return
+        :param tuple inds: indices in sample set to return
 
         :rtype: :class:`~bet.sample.sample_set`
         :returns: the clipped sample set
@@ -626,7 +726,7 @@ class sample_set_base(object):
         for array_name in self.array_names:
             current_array = getattr(sset, array_name)
             if current_array is not None:
-                new_array = current_array[0:cnum]
+                new_array = current_array[inds]
                 setattr(sset, array_name, new_array)
         if sset._values_local is not None:
             sset.global_to_local()
@@ -735,6 +835,7 @@ class sample_set_base(object):
         self._values = util.fix_dimensions_data(values, self._dim)
         if self._values.shape[1] != self._dim:
             raise dim_not_matching("dimension of values incorrect")
+        self._values_local = None
 
     def get_values(self):
         """
@@ -769,7 +870,7 @@ class sample_set_base(object):
         """
         return self._domain
 
-    def set_volumes(self, volumes):
+    def set_volumes(self, volumes=None):
         """
         Sets sample cell volumes.
 
@@ -777,7 +878,16 @@ class sample_set_base(object):
         :param volumes: sample cell volumes
 
         """
-        self._volumes = volumes
+        if volumes is not None:
+            self._volumes = volumes
+        else:
+            logging.warning("Setting volumes with prob/density.")
+            dens = self._densities
+            probs = self._probabilities
+            if (dens is None) or (probs is None):
+                self._volumes = None
+            else:
+                self._volumes = probs / dens
 
     def get_volumes(self):
         """
@@ -789,7 +899,7 @@ class sample_set_base(object):
         """
         return self._volumes
 
-    def set_probabilities(self, probabilities):
+    def set_probabilities(self, probabilities=None):
         """
         Set sample probabilities.
 
@@ -797,7 +907,16 @@ class sample_set_base(object):
         :param probabilities: sample probabilities
 
         """
-        self._probabilities = probabilities
+        if probabilities is not None:
+            self._probabilities = probabilities
+        else:
+            logging.warning("Setting probabilities with density*volume.")
+            dens = self._densities
+            vols = self._volumes
+            if (dens is None) or (vols is None):
+                self._probabilities = None
+            else:
+                self._probabilities = dens * vols
 
     def get_probabilities(self):
         """
@@ -968,7 +1087,7 @@ class sample_set_base(object):
         """
         return self._volumes_local
 
-    def set_probabilities_local(self, probabilities_local):
+    def set_probabilities_local(self, probabilities_local=None):
         """
         Set sample local probabilities.
 
@@ -976,7 +1095,16 @@ class sample_set_base(object):
         :param probabilities_local: local sample probabilities
 
         """
-        self._probabilities_local = probabilities_local
+        if probabilities_local is not None:
+            self._probabilities_local = probabilities_local
+        else:
+            logging.warning("Setting probabilities with density*volume.")
+            dens = self._densities_local
+            vols = self._volumes_local
+            if (dens is None) or (vols is None):
+                self._probabilities_local = None
+            else:
+                self._probabilities_local = dens * vols
 
     def get_probabilities_local(self):
         """
@@ -1092,7 +1220,8 @@ class sample_set_base(object):
             int(comm.rank < n_mc_points % comm.size)
         width = self._domain[:, 1] - self._domain[:, 0]
         mc_points = width * np.random.random((n_mc_points_local,
-                                              self._domain.shape[0])) + self._domain[:, 0]
+                                              self._domain.shape[0])) +\
+            self._domain[:, 0]
         (_, emulate_ptr) = self.query(mc_points)
         vol = np.zeros((num,))
         for i in range(num):
@@ -1216,6 +1345,238 @@ class sample_set_base(object):
         Calculate the volumes of cells. Depends on sample set type.
 
         """
+        pass
+
+    def set_distribution(self, dist=None, *args, **kwds):
+        r"""
+        Assign an description of uncertainty for sample set.
+        The type is flexible, but needs to contain the following
+        methods in order to function:
+        - ``.pdf`` - return density values as ``ndarray``
+        - ``.rvs`` - generate random variables
+        - ``.cdf`` - return cumulative distribution value
+        - ``.interval`` - return confidence interval around median
+        It is suggested to pass a ``scipy.stats.distributions`` object.
+        If one is detected, we will automatically handle the pdf and cdf
+        methods to return the product of the marginals as methods.
+
+        Pass any additional keyword arguments to ``dist`` that are required.
+        """
+        if dist is None:
+            from scipy.stats import norm
+            dist = norm
+            self._domain = np.array([[-np.inf, np.inf]] * self._dim)
+        if isinstance(dist, scipy.stats.distributions.rv_frozen):
+            self._distribution = dist
+        elif isinstance(dist, str):
+            if dist in ['uni', 'uniform']:
+                dist = scipy.stats.uniform
+            elif dist in ['norm', 'normal', 'gauss', 'gaussian']:
+                dist = scipy.stats.norm
+            elif dist in ['beta']:
+                dist = scipy.stats.beta
+            else:
+                raise AttributeError("Inappropriate dist specified.")
+            self._distribution = dist(*args, **kwds)
+        else:
+            self._distribution = dist(*args, **kwds)
+        try:  # set domain based on distribution
+            mins, maxs = self._distribution.interval(1)
+            domain = np.zeros((self._dim, 2))
+            domain[:, 0], domain[:, 1] = mins, maxs
+            self._domain = domain
+        except ValueError:
+            raise dim_not_matching("Dimensions incorrectly specified.")
+        except AttributeError:
+            logging.warning("Could not infer domain from distribution.")
+
+    def set_dist(self, dist=None, *args, **kwds):
+        """
+        Wrapper for ``set_distribution``
+        """
+        return self.set_distribution(dist, *args, **kwds)
+
+    def get_dist(self):
+        """
+        Wrapper for ``get_distribution``
+        """
+        return self.get_distribution()
+
+    def get_distribution(self):
+        """
+        Returns ``distribution``
+        """
+        return self._distribution
+
+    def rvs(self, num=1, dist=None, *args, **kwds):
+        """
+        Returns correctly-shaped random variates.
+        """
+        if dist is None:
+            dist = self._distribution
+        # instantiate class if need be.
+        if isinstance(dist, scipy.stats.distributions.rv_continuous):
+            dist = dist(*args, **kwds)
+        if isinstance(dist, scipy.stats.gaussian_kde):
+            return dist.resample(num).T
+        else:
+            try:
+                if self._dim == 1:
+                    return dist.rvs(num)
+                else:
+                    return dist.rvs(size=(num, self._dim))
+            except ValueError:
+                return dist.rvs(size=(num, 1))
+
+    def generate_samples(self, num_samples=None, globalize=False,
+                         dist=None, *args, **kwds):
+        """
+        Generate i.i.d samples according to distribution
+        """
+        if num_samples is None:
+            num_samples = self.check_num()
+        # define local number of samples
+        num_samples_local = int(num_samples / comm.size) +\
+            int(comm.rank < num_samples % comm.size)
+        self.set_values_local(self.rvs(num_samples_local,
+                                       dist, *args, **kwds))
+
+        if dist is not None:
+            self.set_distribution(dist, *args, **kwds)
+        # clear existing arrays that depend on samples
+        self.update_bounds_local()
+        self._probabilities_local = None
+        self._volumes_local = None
+        self._jacobians_local = None
+        self._densities_local = None
+        self._kdtree_values_local = None
+        comm.barrier()
+
+        if not globalize:
+            self.local_to_global()
+        else:
+            self._values = None
+        # clear existing arrays that depend on samples
+        self._volumes = None
+        self._jacobians = None
+        self._probabilities = None
+        self._densities = None
+        self._kdtree_values = None
+        self._kdtree = None
+
+    def pdf(self, x=None, dist=None):
+        r"""
+        Evaluate the probability density at a set of points x
+
+        :param x: points for query
+        :type x: :class:`numpy.ndarray` of shape ``(*, dim)``
+        :param dist: distribution with `rvs`, `pdf`, and `cdf` methods
+        :type dist: :class:`scipy.stats.distributions.rv_frozen`
+
+        Note
+        =====
+        If `x` is None, we default to evaluating at `values`.
+        If `dist` is None, we use `self._distribution`.
+        You can specify an alternative distribution to take advantage
+        of the re-formatting of outputs to satisfy our assumptions.
+
+        """
+        if dist is None:
+            dist = self._distribution
+
+        if x is None:
+            if self._values_local is None:
+                self.global_to_local()
+            # if self._values is None:
+            #     self.local_to_global()
+            x_local = self._values_local
+            num = self.check_num()
+        else:  # proessors evaluate subset of points
+            if x.ndim == 1:
+                x = x.reshape(1, -1)
+            num = x.shape[0]
+            # num_per_proc = int(num / comm.size) + \
+            #                int(comm.rank < num % comm.size)
+            # x_local = np.empty((num_per_proc, x.shape[1]), dtype='d')
+            # comm.Scatter(x, x_local, root=0)
+
+            x_local = np.array_split(x, comm.size)[comm.rank]
+
+        if isinstance(dist, scipy.stats.gaussian_kde):
+            D_local = dist.pdf(x_local.T).T  # needs transpose
+        else:
+            if self._dim > 1:
+                try:  # handle `scipy.stats.rv_frozen` objects
+                    D_local = dist.pdf(x_local).prod(axis=1)
+                except np.AxisError:
+                    D_local = dist.pdf(x_local)
+            else:  # 1-dimensional case
+                D_local = dist.pdf(x_local)
+        comm.barrier()
+        densities = util.get_global_values(D_local)
+        assert len(densities) == num  # make sure we return correct size
+        return densities.ravel()  # always return flattened
+
+    def cdf(self, x=None, dist=None):
+        r"""
+        Evaluate the cumulative density at a set of points x
+
+        :param x: points for query
+        :type x: :class:`numpy.ndarray` of shape ``(*, dim)``
+        :param dist: distribution with `rvs`, `pdf`, and `cdf` methods
+        :type dist: :class:`scipy.stats.distributions.rv_frozen`
+
+        Note
+        =====
+        If `x` is None, we default to evaluating at `values`.
+        If `dist` is None, we use `self._distribution`.
+        You can specify an alternative distribution to take advantage
+        of the re-formatting of outputs to satisfy our assumptions.
+
+        """
+        if dist is None:
+            dist = self._distribution
+        if x is None:
+            if self._values_local is None:
+                self.global_to_local()
+            # if self._values is None:
+            #     self.local_to_global()
+            x_local = self._values_local
+            num = self.check_num()
+        else:  # proessors evaluate subset of points
+            if x.ndim == 1:
+                x = x.reshape(1, -1)
+            num = x.shape[0]
+            # num_per_proc = int(num / comm.size) + \
+            #                int(comm.rank < num % comm.size)
+            # x_local = np.empty((num_per_proc, x.shape[1]), dtype='d')
+            # comm.Scatter(x, x_local, root=0)
+
+            x_local = np.array_split(x, comm.size)[comm.rank]
+
+        if isinstance(dist, scipy.stats.gaussian_kde):
+            C_local = dist.cdf(x_local.T).T  # needs transpose
+        else:
+            if self._dim > 1:
+                try:  # handle `scipy.stats.rv_frozen` objects
+                    C_local = dist.cdf(x_local).prod(axis=1)
+                except np.AxisError:
+                    C_local = dist.cdf(x_local)
+            else:  # 1-dimensional case
+                C_local = dist.cdf(x_local)
+        cumulatives = util.get_global_values(C_local)
+        assert len(cumulatives) == num
+        return cumulatives.ravel()  # always return flattened
+
+    def estimate_probabilities_mc(self, globalize=True):
+        """
+        Give all cells the same probability fraction
+        based on the Monte Carlo assumption.
+        """
+        num = self.check_num()
+        self._probabilities = 1.0 / float(num) * np.ones((num,))
+        if globalize:
+            self.global_to_local()
 
 
 def save_discretization(save_disc, file_name, discretization_name=None,
@@ -1247,7 +1608,8 @@ def save_discretization(save_disc, file_name, discretization_name=None,
     if comm.size > 1 and not globalize:
         local_file_name = os.path.join(os.path.dirname(file_name),
                                        "proc{}_{}".format(comm.rank,
-                                                          os.path.basename(file_name)))
+                                                          os.path.
+                                                          basename(file_name)))
     else:
         local_file_name = file_name
 
@@ -1270,7 +1632,7 @@ def save_discretization(save_disc, file_name, discretization_name=None,
     # create temporary dictionary
     if os.path.exists(local_file_name) or \
             os.path.exists(local_file_name + '.mat'):
-        new_mdat = sio.loadmat(local_file_name)
+        new_mdat = loadmat(local_file_name)
 
     # store discretization in dictionary
     for attrname in discretization.vector_names:
@@ -1283,7 +1645,7 @@ def save_discretization(save_disc, file_name, discretization_name=None,
 
     # save new file or append to existing file
     if (globalize and comm.rank == 0) or not globalize:
-        sio.savemat(local_file_name, new_mdat)
+        savemat(local_file_name, new_mdat)
     comm.barrier()
     return local_file_name
 
@@ -1325,11 +1687,11 @@ def load_discretization_parallel(file_name, discretization_name=None):
         if discretization_name is None:
             discretization_name = 'default'
 
-        input_sample_set = load_sample_set(file_name,
-                                           discretization_name + '_input_sample_set')
+        input_sample_set = load_sample_set(file_name, discretization_name +
+                                           '_input_sample_set')
 
-        output_sample_set = load_sample_set(file_name,
-                                            discretization_name + '_output_sample_set')
+        output_sample_set = load_sample_set(file_name, discretization_name +
+                                            '_output_sample_set')
 
         loaded_disc = discretization(input_sample_set, output_sample_set)
 
@@ -1337,7 +1699,7 @@ def load_discretization_parallel(file_name, discretization_name=None):
         # otherwise gather the data from mdat and then scatter
         # among the processors and update mdat
         mdat_files_local = comm.scatter(mdat_files)
-        mdat_local = [sio.loadmat(m) for m in mdat_files_local]
+        mdat_local = [loadmat(m) for m in mdat_files_local]
         mdat_list = comm.allgather(mdat_local)
         mdat_global = []
         # instead of a list of lists, create a list of mdat
@@ -1360,8 +1722,9 @@ def load_discretization_parallel(file_name, discretization_name=None):
         for attrname in discretization.sample_set_names:
             if attrname is not '_input_sample_set' and \
                     attrname is not '_output_sample_set':
-                setattr(loaded_disc, attrname, load_sample_set(file_name,
-                                                               discretization_name + attrname))
+                setattr(loaded_disc, attrname,
+                        load_sample_set(file_name,
+                                        discretization_name + attrname))
 
         # re-localize if necessary
         if file_name.startswith('proc_') and comm.size > 1 \
@@ -1369,9 +1732,9 @@ def load_discretization_parallel(file_name, discretization_name=None):
             warn_string = "Local pointers have been removed and will be"
             warn_string += " re-created as necessary)"
             warnings.warn(warn_string)
-            #loaded_disc._io_ptr_local = None
-            #loaded_disc._emulated_ii_ptr_local = None
-            #loaded_disc._emulated_oo_ptr_local = None
+            loaded_disc._io_ptr_local = None
+            loaded_disc._emulated_ii_ptr_local = None
+            loaded_disc._emulated_oo_ptr_local = None
     return loaded_disc
 
 
@@ -1401,7 +1764,8 @@ def load_discretization(file_name, discretization_name=None):
             "proc{}_{}".format(comm.rank, os.path.basename(file_name)))):
         return load_discretization_parallel(file_name, discretization_name)
 
-    mdat = sio.loadmat(file_name)
+    mdat = loadmat(file_name)
+
     if discretization_name is None:
         discretization_name = 'default'
 
@@ -1779,7 +2143,8 @@ class voronoi_sample_set(sample_set_base):
             # Calculate mean, std of pairwise distances
             # TODO this may be too large/small
             # Estimate radius as 2.*STD of the pairwise distance
-            sample_radii[sample_radii <= 0] = prob_est_radii[sample_radii <= 0]
+            sample_radii[sample_radii <=
+                         0] = prob_est_radii[sample_radii <= 0]
 
         # determine the volume of the Lp ball
         if not np.isinf(self._p_norm):
@@ -1930,7 +2295,7 @@ class rectangle_sample_set(sample_set_base):
         if len(maxes) > 1:
             msg = "If rectangles intersect on a set nonzero measure, "
             msg += "calculated values will be wrong."
-            logging.warning(msg)
+#             logging.warning(msg)
         self._region = np.arange(len(maxes) + 1)
 
     def update_bounds(self, num=None):
@@ -2060,7 +2425,10 @@ class rectangle_sample_set(sample_set_base):
         num = self.check_num()
         self._volumes = np.zeros((num, ))
         domain_width = self._domain[:, 1] - self._domain[:, 0]
-        self._volumes[0:-1] = np.prod(self._width[0:-1] / domain_width, axis=1)
+        self._volumes[0:-
+                      1] = np.prod(self._width[0:-
+                                               1] /
+                                   domain_width, axis=1)
         self._volumes[-1] = 1.0 - np.sum(self._volumes[0:-1])
 
 
@@ -2088,10 +2456,12 @@ class ball_sample_set(sample_set_base):
 
         """
         if len(centers) != len(radii):
-            raise length_not_matching("Different number of centers and radii.")
+            raise length_not_matching(
+                "Different number of centers and radii.")
         for i in range(len(centers)):
             if len(centers[i]) != self._dim:
-                msg = "Center " + repr(i) + " has the wrong number of entries."
+                msg = "Center " + repr(i) + \
+                    " has the wrong number of entries."
                 raise length_not_matching(msg)
         values = np.zeros((len(centers) + 1, self._dim))
         values[0:-1, :] = centers
@@ -2291,11 +2661,13 @@ class discretization(object):
     #: List of attribute names for attributes which are vectors or 1D
     #: :class:`numpy.ndarray`
     vector_names = ['_io_ptr', '_io_ptr_local', '_emulated_ii_ptr',
-                    '_emulated_ii_ptr_local', '_emulated_oo_ptr', '_emulated_oo_ptr_local']
+                    '_emulated_ii_ptr_local', '_emulated_oo_ptr',
+                    '_emulated_oo_ptr_local']
     #: List of attribute names for attributes that are
     #: :class:`sample.sample_set_base`
     sample_set_names = ['_input_sample_set', '_output_sample_set',
-                        '_emulated_input_sample_set', '_emulated_output_sample_set',
+                        '_emulated_input_sample_set',
+                        '_emulated_output_sample_set',
                         '_output_probability_set']
 
     def __init__(self, input_sample_set, output_sample_set,
@@ -2327,9 +2699,23 @@ class discretization(object):
         self._emulated_ii_ptr_local = None
         #: local emulated oo ptr for parallelism
         self._emulated_oo_ptr_local = None
+        #: iteration number
+        self._iteration = 0
+        #: iteration dictionary to hold information
+        self._setup = {0: {'col': False,
+                           'rep': False,
+                           'ind': None,
+                           'qoi': 'SWE',
+                           'std': None,
+                           'obs': None,
+                           'pre': None,
+                           'model': None}}
 
         if output_sample_set is not None:
             self.check_nums()
+            # TK - edit this out
+            # if output_probability_set is not None:
+            #    self.set_io_ptr(globalize=True)
         else:
             logging.info("No output_sample_set")
 
@@ -2367,6 +2753,16 @@ class discretization(object):
                 (self._emulated_oo_ptr is None):
             self._emulated_oo_ptr = util.get_global_values(
                 self._emulated_oo_ptr_local)
+
+    def local_to_global(self):
+        """
+        Call local_to_global for ``input_sample_set`` and
+        ``output_sample_set``.
+        """
+        if self._input_sample_set is not None:
+            self._input_sample_set.local_to_global()
+        if self._output_sample_set is not None:
+            self._output_sample_set.local_to_global()
 
     def set_io_ptr(self, globalize=True):
         """
@@ -2506,6 +2902,17 @@ class discretization(object):
             current_array = getattr(self, array_name)
             if current_array is not None:
                 setattr(my_copy, array_name, np.copy(current_array))
+        # copy setup information
+        if self._setup is not None:
+            import copy
+            my_copy._setup = copy.deepcopy(self._setup)
+        initial = self.get_initial()
+        if initial is not None:
+            my_copy.set_initial(
+                initial.dist,
+                gen=False,
+                *initial.args,
+                **initial.kwds)
         return my_copy
 
     def get_input_sample_set(self):
@@ -2594,9 +3001,15 @@ class discretization(object):
                 raise dim_not_matching("dimension of values incorrect")
         else:
             raise AttributeError("Wrong Type: Should be sample_set_base type")
-        if self._output_sample_set._values_local is not None:
-            if output_probability_set._values is not None:
-                self.set_io_ptr(globalize=False)
+        if self._output_sample_set is not None:
+            if self._output_sample_set._values_local is not None:
+                num = self._output_sample_set._values_local.shape[1]
+                if output_probability_set._values is not None:
+                    try:
+                        self.set_io_ptr(globalize=False)
+                    except dim_not_matching:  # handle data-driven case
+                        raise AttributeError("DATA DRIVEN")
+                        self._io_ptr_local = np.arange(num)
 
     def get_emulated_output_sample_set(self):
         """
@@ -2634,6 +3047,10 @@ class discretization(object):
                 raise dim_not_matching("dimension of values incorrect")
         else:
             raise AttributeError("Wrong Type: Should be sample_set_base type")
+        if self._output_sample_set is not None:
+            if self._output_sample_set._values_local is not None:
+                if emulated_output_sample_set._values is not None:
+                    self.set_emulated_oo_ptr(globalize=False)
 
     def get_emulated_input_sample_set(self):
         """
@@ -2667,6 +3084,9 @@ class discretization(object):
                 self._emulated_input_sample_set = emulated_input_sample_set
         else:
             raise AttributeError("Wrong Type: Should be sample_set_base type")
+        if self._input_sample_set._values_local is not None:
+            if emulated_input_sample_set._values is not None:
+                self.set_emulated_ii_ptr(globalize=False)
 
     def estimate_input_volume_emulated(self):
         """
@@ -2716,12 +3136,36 @@ class discretization(object):
         """
         ci = self._input_sample_set.clip(cnum)
         co = self._output_sample_set.clip(cnum)
-
+        ps = self._output_probability_set
+        ei = self._emulated_input_sample_set
+        eo = self._emulated_output_sample_set
         return discretization(input_sample_set=ci,
                               output_sample_set=co,
-                              output_probability_set=self._output_probability_set,
-                              emulated_input_sample_set=self._emulated_input_sample_set,
-                              emulated_output_sample_set=self._emulated_output_sample_set)
+                              output_probability_set=ps,
+                              emulated_input_sample_set=ei,
+                              emulated_output_sample_set=eo)
+
+    def clip_samples(self, inds):
+        """
+        Creates and returns a discretization with samples indexed by
+        `inds`, of the input and output sample sets.
+
+        :param tuple inds: indices of values of sample set to return
+
+        :rtype: :class:`~bet.sample.discretization`
+        :returns: clipped discretization
+
+        """
+        ci = self._input_sample_set.clip(inds)
+        co = self._output_sample_set.clip(inds)
+        ps = self._output_probability_set
+        ei = self._emulated_input_sample_set
+        eo = self._emulated_output_sample_set
+        return discretization(input_sample_set=ci,
+                              output_sample_set=co,
+                              output_probability_set=ps,
+                              emulated_input_sample_set=ei,
+                              emulated_output_sample_set=eo)
 
     def merge(self, disc):
         """
@@ -2736,24 +3180,24 @@ class discretization(object):
         """
         mi = self._input_sample_set.merge(disc._input_sample_set)
         mo = self._output_sample_set.merge(disc._output_sample_set)
-        mei = self._emulated_input_sample_set.merge(disc.
-                                                    _emulated_input_sample_set)
-        meo = self._emulated_output_sample_set.merge(disc.
-                                                     _emulated_output_sample_set)
+        mei = self._emulated_input_sample_set.\
+            merge(disc._emulated_input_sample_set)
+        meo = self._emulated_output_sample_set.\
+            merge(disc._emulated_output_sample_set)
 
         return discretization(input_sample_set=mi,
                               output_sample_set=mo,
-                              output_probability_set=self._output_probability_set,
+                              output_probability_set=self.
+                              _output_probability_set,
                               emulated_input_sample_set=mei,
                               emulated_output_sample_set=meo)
 
-    def choose_inputs_outputs(self,
-                              inputs=None,
-                              outputs=None):
+    def choose_outputs(self, outputs=None):
         """
-        Slices the inputs and outputs of the discretization.
+        Slices outputs of discretization (columns) and returns object with the
+        same input sample set. For new instances, use `choose_inputs_outputs`.
+        This function is of particular use for iterated ansatzs.
 
-        :param list inputs: list of indices of input sample set to include
         :param list outputs: list of indices of output sample set to include
 
         :rtype: :class:`~bet.sample.discretization`
@@ -2762,7 +3206,49 @@ class discretization(object):
         """
         slice_list = ['_values', '_values_local',
                       '_error_estimates', '_error_estimates_local']
+
+        output_ss = sample_set(len(outputs))
+        output_ss.set_p_norm(self._output_sample_set._p_norm)
+        if self._output_sample_set._domain is not None:
+            output_ss.set_domain(self._output_sample_set._domain[outputs, :])
+        if self._output_sample_set._reference_value is not None:
+            output_ss.set_reference_value(
+                self._output_sample_set._reference_value[outputs])
+
+        for obj in slice_list:
+            val = getattr(self._output_sample_set, obj)
+            if val is not None:
+                setattr(output_ss, obj, val[:, outputs])
+
+        disc = discretization(input_sample_set=self._input_sample_set,
+                              output_sample_set=output_ss)
+        return disc
+
+    def choose_inputs_outputs(self,
+                              inputs=None,
+                              outputs=None):
+        """
+        Slices the inputs and outputs of the discretization (columns).
+
+        :param list inputs: list of indices of input sample set to include.
+        :param list outputs: list of indices of output sample set to include
+
+        :rtype: :class:`~bet.sample.discretization`
+        :returns: sliced discretization
+
+         .. note ::
+            If you pass None instead of list, all indices are kept.
+            This can be useful for re-arranging the order of variables,
+            creating repeated columns of data, or truncating spaces.
+        """
+        slice_list = ['_values', '_values_local',
+                      '_error_estimates', '_error_estimates_local']
         slice_list2 = ['_jacobians', '_jacobians_local']
+
+        if inputs is None:  # instead of error message, copy input.
+            inputs = np.arange(self._input_sample_set._dim)
+        if outputs is None:  # instead of error message, copy output.
+            outputs = np.arange(self._output_sample_set._dim)
 
         input_ss = sample_set(len(inputs))
         output_ss = sample_set(len(outputs))
@@ -2798,12 +3284,1017 @@ class discretization(object):
                               output_sample_set=output_ss)
         return disc
 
-    def local_to_global(self):
+    def likelihood(self, x=None):
+        L = self._output_probability_set._distribution
+        flip = False
+        if self._setup[self._iteration]['col']:
+            flip = True
+            self._setup[self._iteration]['col'] = False
+        if x is None:
+            x = self.format_output_values()
+        else:
+            x = self.format_output_values(x)
+        if flip:
+            self._setup[self._iteration]['col'] = True
+        # our pdf function already returns products.
+        return self._output_probability_set.pdf(x=x, dist=L)
+
+    def set_likelihood(self, dist=None):
         """
-        Call local_to_global for ``input_sample_set`` and
-        ``output_sample_set``.
+        TO DO: set this up properly
         """
-        if self._input_sample_set is not None:
-            self._input_sample_set.local_to_global()
-        if self._output_sample_set is not None:
-            self._output_sample_set.local_to_global()
+        flip = False
+        if self._setup[self._iteration]['col']:
+            flip = True
+            self._setup[self._iteration]['col'] = False
+        if dist is None:
+            obs = self.get_observed_distribution()
+        else:
+            obs = dist
+        std = self.get_std()
+        data = self.get_data()
+        if data is None:
+            logging.warning("Missing data. Using mean of observed.")
+            data = obs.mean()
+        if flip:
+            self._setup[self._iteration]['col'] = True
+        self._output_probability_set._dim = len(data)
+        self._output_probability_set.set_distribution(
+            dist=obs.dist, scale=std, loc=data)
+
+    def get_initial_distribution(self):
+        return self._input_sample_set.get_distribution()
+
+    def get_initial(self):
+        return self.get_initial_distribution()
+
+    def get_observed_distribution(self, iteration=None):
+        if iteration is None:
+            iteration = self._iteration
+        return self._setup[iteration]['obs']
+
+    def get_observed(self, iteration=None):
+        return self.get_observed_distribution(iteration)
+
+    def get_predicted(self, iteration=None):
+        return self.get_predicted_distribution(iteration)
+
+    def get_predicted_distribution(self, iteration=None):
+        if iteration is None:
+            iteration = self._iteration
+        return self._setup[iteration]['pre']
+
+    def set_predicted_distribution(self, dist=None,
+                                   iteration=None, *args, **kwds):
+        r"""
+        Wrapper for `compute_pushforward` if `dist==None`. Otherwise this
+        function sets the predicted distribution (the distribution associated
+        with the `output_sample_set` in the `discretization`.
+        """
+        if dist is None:
+            return self.compute_pushforward(dist, iteration)
+        elif isinstance(dist, scipy.stats._continuous_distns.rv_continuous) or \
+                isinstance(dist, scipy.stats._distn_infrastructure.rv_frozen):
+            self._output_sample_set.set_distribution(dist, *args, **kwds)
+            if iteration is None:
+                iteration = self._iteration
+            self._setup[iteration]['pre'] = self._output_sample_set.\
+                get_distribution()
+        else:
+            return self.compute_pushforward(dist, iteration, *args, **kwds)
+
+    def set_predicted(self, dist=None, iteration=None, *args, **kwds):
+        r"""
+        Wrapper for `set_predicted_distribution`.
+        """
+        return self.set_predicted_distribution(dist, iteration, *args, **kwds)
+
+    def set_initial_distribution(
+            self, dist=None, num=None, gen=True, *args, **kwds):
+        r"""
+        If dist=None and num is not None, then just re-generate
+        samples and map outputs using existing distribution.
+        """
+
+        if num is None:
+            num = self._input_sample_set.check_num()
+
+        if dist is None:
+            if self._input_sample_set._distribution is None:
+                logging.warning("Assuming independent Gaussian.")
+                self._input_sample_set.set_distribution()
+            else:  # do not change existing distribution.
+                pass
+        else:  # if a new distribution is specified, re-generate samples
+            self._input_sample_set.set_distribution(dist, *args, **kwds)
+        if gen:
+            self._input_sample_set.generate_samples(num)
+            
+            # map output samples
+            lam_ref = self._input_sample_set._reference_value
+            # initialize output samples
+            y = np.zeros((num, 1))  # temporary vector of correct shape
+            v = np.array([])
+            # TK - TODO: support string-indexed dictionaries, consistent order,
+            # unify with pdf methods.
+            for iteration in self._setup.keys():  # map through every model
+                # clear all push-forwards
+                self._setup[iteration]['pre'] = None
+                model = self._setup[iteration]['model']
+                # ensure model output size is consistent
+                if model is not None:
+                    z = model(self._input_sample_set._values)
+                    if lam_ref is not None:
+                        try:  # handle reference value
+                            v = np.concatenate((v, model(lam_ref)), axis=0)
+                        except ValueError:  # handle scalar models
+                            v = np.column_stack(
+                                (v, model(lam_ref).reshape(1,)))
+                    try:
+                        y = np.column_stack((y, z))
+                    except np.AxisError:  # handle scalar models
+                        y = np.concatenate((y, z.reshape(-1, 1)), axis=1)
+            y = y[:, 1:]  # remove zeros
+            self._output_sample_set._dim = y.shape[1]
+            self._output_sample_set.set_values(y)
+            if lam_ref is not None:
+                self._output_sample_set.set_reference_value(v)
+
+    def set_initial(self, dist=None, num=None, gen=True, *args, **kwds):
+        r"""
+        Wrapper for `set_initial_distribution`.
+        """
+        return self.set_initial_distribution(dist, num, gen, *args, **kwds)
+
+    def set_observed_distribution(
+            self, dist=None, iteration=None, *args, **kwds):
+        r"""
+        Set output_probability_set._distribution. Default assumption is N(0,1).
+        """
+
+        # the purpose of the probability set is to hold the evaluations
+        # of the QoI at the current iteration step in its values.
+        # also, to build in support for voronoi-cell approach (TODO later)
+        if iteration is None:
+            iteration = self._iteration
+
+        inds = self.get_output_indices(iteration)  # returns ALL if None
+        dim = len(inds)
+        if self._output_probability_set is None:
+            self.set_output_probability_set(sample_set(dim))
+        self._output_probability_set._dim = dim  # will need this to match.
+
+        if dist is None:  # normal by default
+            from scipy.stats.distributions import norm
+            dist = norm
+            logging.info("Assuming normal distribution of noise.")
+        try:  # is user providing information about error?
+            scale = kwds.pop('scale')
+            # enforce correct size of distribution.
+            if isinstance(scale, float) or isinstance(scale, int):
+                scale = scale * np.ones(dim)
+        except KeyError:
+            scale = np.ones(dim)
+
+        self._output_probability_set._dim = dim  # write dimension info
+        self._output_probability_set.set_distribution(
+            dist, scale=scale, *args, **kwds)
+        # Store distribution for iterated re-use
+        obs_dist = self._output_probability_set._distribution
+        self._setup[iteration]['obs'] = obs_dist
+
+        # Store information about standard deviation for later use.
+        logging.info(
+            "Setting standard deviation information for output data.")
+        self.set_std(obs_dist.std(), iteration=iteration)
+
+    def set_observed(self, dist=None, iteration=None, *args, **kwds):
+        r"""
+        Wrapper for ``set_observed_distribution``
+        """
+        return self.set_observed_distribution(dist, iteration, *args, **kwds)
+
+    def compute_pushforward(self, dist=None, iteration=None, *args, **kwds):
+        # avoid accept/reject if possible
+        if iteration is None:  # if not provided, assume "current"
+            iteration = self._iteration
+
+        self._output_sample_set.local_to_global()
+        data = self.format_output_values(iteration=iteration)
+        if data is None:
+            raise AttributeError("Missing output values")
+
+        if dist is None:
+            from scipy.stats import gaussian_kde as gkde
+            self._output_sample_set._distribution = gkde(
+                data.T, *args, **kwds)
+        elif isinstance(dist, str):
+            self._output_sample_set.set_distribution(dist, *args, **kwds)
+        else:
+            self._output_sample_set._distribution = dist(data, *args, **kwds)
+
+        # Store distribution for iterated re-use
+        self._setup[iteration]['pre'] = self._output_sample_set._distribution
+
+    # move this somewhere else:
+    def iterate(self):
+        # what to copy over? what to leave as default?
+        self._iteration += 1
+        it = self._iteration
+        self.default_setup()
+        # inherit all features in the new iteration
+        self._setup[it] = self._setup[it - 1].copy()
+        pass
+
+    def set_iteration(self, iteration=0):
+        self._iteration = iteration
+
+    def initial_pdf(self, x=None):
+        return self._input_sample_set.pdf(x)
+
+    def predicted_pdf(self, x=None, iteration=None):
+        if iteration is None:  # if not provided, assume "current"
+            iteration = self._iteration
+
+        if self._setup[iteration]['pre'] is None:
+            logging.info("Missing predicted distribution. Computing now.")
+            self.compute_pushforward(iteration=iteration)
+
+        for i in range(0, iteration + 1):  # get all previous
+            data_driven_status = self._setup[i]['col']
+            if data_driven_status:
+                s = self._setup[i]['qoi']
+                logging.info("Iteration %i is using %s." % (i, s))
+            pre = self._setup[i]['pre']  # load predicted dist
+            data = self.format_output_values(x=x, iteration=i)
+            temp_eval = np.log(self._output_sample_set.pdf(x=data,
+                                                           dist=pre))
+            if i == 0:
+                out = temp_eval
+            else:
+                out += temp_eval
+
+        return np.exp(out)
+
+    def observed_pdf(self, x=None, iteration=None):
+        r"""
+        Evaluate the observed pdf on a provided set of points.
+
+        Notes
+        -----
+        This is an alias for `~bet.sample.sample_set.pdf`.  See the ``pdf``
+        docstring for more details.
+
+        :param x: points for evaluation of probability density function
+        :type x: :class:`numpy.ndarray` of shape ``(*, dim)``
+
+        """
+        if iteration is None:  # if not provided, assume "current"
+            iteration = self._iteration
+
+        for i in range(0, iteration + 1):  # get all previous
+            data = self.format_output_values(x=x, iteration=i)
+            dim = data.shape[1]
+            data_driven_status = self._setup[i]['col']
+            if data_driven_status:
+                data_driven_mode = self._setup[i]['qoi']
+                if data_driven_mode is 'SWE':
+                    from scipy.stats.distributions import norm
+                    obs = norm(loc=0, scale=1)
+                elif data_driven_mode is 'MSE':
+                    from scipy.stats.distributions import gamma
+                    obs = gamma(a=dim / 2.0, scale=2.0 / dim)
+                elif data_driven_mode is 'SSE':
+                    from scipy.stats.distributions import chi2
+                    obs = chi2(df=dim)
+                else:
+                    raise ValueError("Could not infer QoI type.")
+            else:  # attempt to set observed based on stored info
+                obs = self._setup[i]['obs']  # load observed dist
+
+            temp_eval = self._output_probability_set.pdf(x=data, dist=obs)
+            if i == 0:
+                out = temp_eval
+            else:
+                out *= temp_eval
+        return out
+
+    def ratio_pdf(self, x=None):
+        r"""
+        Evaluate the estimated ratio pdf on a provided set of points.
+        The ratio is the observed to the predicted densities.
+
+        Notes
+        -----
+        This is a convenience alias for division between two evaluations of
+        `~bet.sample.sample_set.pdf`.
+        See the ``pdf`` docstring for more details.
+
+        :param x: points for evaluation of probability density function
+        :type x: :class:`numpy.ndarray` of shape ``(*, dim)``
+
+        """
+        return self.observed_pdf(x) / self.predicted_pdf(x)
+
+    def normalized_ratio(self, x=None):
+        r"""
+        Evaluate the estimated ratio pdf on a provided set of points.
+        The ratio is the observed to the predicted densities.
+        Then, divide by the maximum.
+
+        Notes
+        -----
+        This is a convenience alias for `~bet.sample.discretization.ratio_pdf`.
+        It performs normalization, returning ratio/max(ratio).
+        This is particularly helpful for accept/reject procedures.
+
+        """
+        ratio = self.ratio_pdf(x)
+        return ratio / max(ratio)
+
+    def get_input_values(self):
+        return self._input_sample_set._values
+
+    def get_output_values(self):
+        return self._output_sample_set._values
+
+    def set_model(self, model, iteration=None):
+        if iteration is None:
+            iteration = self._iteration
+        if self._setup[iteration]['model'] is not None:
+            msg = "Overwriting existing model, but not mapping outputs. "
+            msg += "Run`.set_initial(gen=False)` to re-compute output values."
+            logging.warning(msg)
+        self._setup[iteration]['model'] = model
+
+    def updated_pdf(self, x=None, iteration=None):
+        r"""
+        Evaluate the updated pdf on a provided set of points.
+
+        :param x: points for evaluation of probability density function
+        :type x: :class:`numpy.ndarray` of shape ``(*, dim)``
+
+        """
+        if iteration is None:
+            iteration = self._iteration
+
+        check_num = False
+        if x is None:
+            x = self._input_sample_set._values
+            y = self._output_sample_set._values
+            check_num = True
+        else:
+            num = x.shape[0]
+            y = np.empty((num, 0))  # temporary vector of correct shape
+
+            for iteration in self._setup.keys():  # map through every model
+                inds = self.get_output_indices(iteration)
+                unique = len(np.unique(inds))
+                model = self._setup[iteration]['model']
+                # ensure model output size
+                if model is not None:
+                    z = model(x).reshape(num, unique)[:, inds]
+                    y = np.concatenate((y, z), axis=1)
+
+        den = self.initial_pdf(x) * self.ratio_pdf(y)
+        if check_num:
+            assert len(den) == self.check_nums()
+            self._input_sample_set.set_densities(den)
+        else:
+            assert len(den) == x.shape[0]
+        return den
+
+    def set_probabilities_from_densities(self):
+        """
+        """
+        dens = self.updated_pdf()
+        # initial probability is 1/N, density known.
+        vols = 1. / (self.check_nums() * self.initial_pdf())
+        probs = dens * vols
+        self._input_sample_set.set_probabilities(probs / np.sum(probs))
+        self._input_sample_set.set_volumes(vols)
+
+    def set_prob_from_den(self):
+        return self.set_probabilities_from_densities()
+
+    def clip_accepted_samples(self):
+        """
+        Perform accept/reject and return a new sample set
+        containing only the subset of samples that
+        are distributed according to the updated density.
+        """
+        ratio = self.normalized_ratio()
+        num_samples = self.check_nums()
+        randnums = np.random.rand(num_samples)
+        accept_inds = [i for i in range(num_samples)
+                       if ratio[i] > randnums[i]]
+        return self.clip_samples(accept_inds)
+
+    def mud_index(self, x=None, iteration=None):
+        """
+        Return index of maximum updated density value.
+        """
+        den = self.updated_pdf(x, iteration)
+        mud_idx = np.argmax(den)
+        return mud_idx
+
+    def mud_point(self, x=None, iteration=None):
+        """
+        Return maximum updated density value.
+        """
+        mud_idx = self.mud_index(x, iteration)
+        return self._input_sample_set._values[mud_idx, :]
+
+    def mud_value(self, x=None, iteration=None):
+        """
+        Return output value corresponding to maximum updated density value.
+        """
+        mud_idx = self.mud_index(x, iteration)
+        return self._output_sample_set._values[mud_idx, :]
+
+    def posterior_pdf(self, x=None, iteration=None):
+        r"""
+        Evaluate the updated pdf on a provided set of points.
+
+        :param x: points for evaluation of probability density function
+        :type x: :class:`numpy.ndarray` of shape ``(*, dim)``
+
+        """
+        if iteration is None:
+            iteration = self._iteration
+
+        if x is None:
+            x = self._input_sample_set._values
+            y = self._output_sample_set._values
+        else:
+            y = np.zeros((x.shape[0], 1))  # temporary vector of correct shape
+
+            for iteration in self._setup.keys():  # map through every model
+                inds = self.get_output_indices(iteration)
+                unique = len(np.unique(inds))
+                model = self._setup[iteration]['model']
+                # ensure model output size
+                if model is not None:
+                    z = model(x).reshape(-1, unique)[:, inds]
+                    y = np.concatenate((y, z), axis=1)
+
+            y = y[:, 1:]  # remove zeros
+        den = self.initial_pdf(x) * self.likelihood(y)
+        if x is not None:
+            assert len(den) == x.shape[0]
+        else:
+            assert len(den) == self.check_nums()
+        return den
+
+    def map_index(self, x=None, iteration=None):
+        """
+        Return index of maximum aposteriori point.
+        """
+        den = self.posterior_pdf(x, iteration)
+        map_idx = np.argmax(den)
+        return map_idx
+
+    def map_point(self, x=None, iteration=None):
+        """
+        Return maximum aposteriori point.
+        """
+        map_idx = self.map_index(x, iteration)
+        return self._input_sample_set._values[map_idx, :]
+
+    def map_value(self, x=None, iteration=None):
+        """
+        Return output value corresponding to maximum aposteriori point.
+        """
+        map_idx = self.map_index(x, iteration)
+        return self._output_sample_set._values[map_idx, :]
+
+    def set_noise_model(self, dist=None, iteration=None, *args, **kwds):
+        """
+        dist can be a number, in which case dimension is inferred
+        from indices
+        """
+        if iteration is None:
+            iteration = self._iteration
+        if dist is None:
+            logging.warning("Assuming Normal, pulling from get_std.")
+            dist = self.get_std(iteration)
+        logging.info(
+            "With this option, you will be inferring std from observed.")
+        from scipy.stats.distributions import norm
+        dim_output = len(self.get_output_indices(iteration))
+        if self._setup[iteration]['rep'] is not None:
+            dim_output = 1
+        if isinstance(dist, int) or isinstance(dist, float):
+            std = np.ones(dim_output) * dist
+            dist = norm(scale=std)
+        elif isinstance(dist, list) or isinstance(dist, tuple):
+            if len(dist) != dim_output:
+                raise dim_not_matching("Does not match data dimension.")
+            std = np.array(dist)
+            dist = norm(scale=std)
+        elif isinstance(dist, np.ndarray):
+            std = dist
+            dist = norm(scale=std)
+
+        if isinstance(dist, scipy.stats.distributions.rv_frozen):
+            self._setup[self._iteration]['obs'] = dist  # store it
+            std = self._setup[self._iteration]['obs'].std()
+        else:
+            self._setup[self._iteration]['obs'] = dist(*args, **kwds)
+            std = self._setup[self._iteration]['obs'].std()
+        self._setup[self._iteration]['std'] = None
+        self._setup[self._iteration]['pre'] = None
+
+    def loss_fun(self, outputs, data, data_std, mode='SWE'):
+        # if std vector has shape mismatch, this will error out:
+        weighted_residuals = np.divide((outputs - data), data_std)
+        if mode is 'SWE':  # sum weighted errors
+            qoi = np.sum(weighted_residuals, axis=1)
+        elif mode is 'MSE':  # mean squared error
+            qoi = (1. / np.sqrt(len(data))) * \
+                np.sum(np.power(weighted_residuals, 2), axis=1)
+        elif mode is 'SSE':  # sum squared error
+            qoi = np.sum(np.power(weighted_residuals, 2), axis=1)
+        else:
+            raise ValueError("Choose mode from [SWE, MSE, SSE]")
+        # always returning 1-D output from this function.
+        return qoi.reshape(-1, 1)
+
+    def format_output_values(self, x=None, iteration=None):
+        if iteration is None:  # get current if None
+            iteration = self._iteration
+        inds = self.get_output_indices(iteration=iteration)
+        if x is None:  # grab most recent values by default
+            qoi = self._output_sample_set._values[:, inds]
+        else:  # attempt to parse provided input values
+            try:
+                qoi = x[:, inds]
+            except np.AxisError:  # row-vector support
+                qoi = x[inds].reshape(-1, 1)
+            except IndexError:  # perhaps just passing relevant
+                logging.warning("Could not index data. Setting as-is.")
+                qoi = x  # support already-formatted data
+
+        # Now our data is the correct dimension to be passed
+        # to both observed and predicted, unless data-driven.
+        # if data-driven, we have to collapse the data and write it
+        # to output_probability_set.
+        data_driven_status = self._setup[iteration]['col']
+
+        # we now have to transform our QoI data if we are in data-driven mode.
+        if data_driven_status:
+            data_driven_mode = self._setup[iteration]['qoi']
+            std = self.get_std(iteration)
+            data = self.get_data(iteration)
+            qoi = self.loss_fun(outputs=qoi, data=data,
+                                data_std=std, mode=data_driven_mode)
+
+        return qoi
+
+    def set_data_driven_mode(self, qoi='SWE', iteration=None):
+        if iteration is None:
+            iteration = self._iteration
+        if qoi in ['SSE', 'MSE', 'SWE']:
+            self._setup[iteration]['qoi'] = qoi
+        else:
+            raise ValueError('Please specify one of SWE/MSE/SWE')
+
+    def set_repeated(self, repeat=None, iteration=None):
+        r"""
+        Toggle mode for repeated observations.
+
+        :param repeat: output indices for repeated observations
+        :type repeat: `float` or `tuple` of :type:`int`, or `int`
+
+        """
+        if iteration is None:
+            iteration = self._iteration
+        if repeat is None:
+            repeat = iteration
+        if isinstance(repeat, list) or isinstance(repeat, tuple):
+            self._setup[iteration]['rep'] = list(np.array(repeat, dtype=int))
+        else:
+            if repeat < 0 or repeat > self._output_sample_set._dim:
+                msg = "Improper output index specified"
+                msg += "for the case of repeated observations."
+                raise ValueError(msg)
+            self._setup[iteration]['rep'] = int(repeat)
+
+    def set_data_driven(self, collapse=True, iteration=None):
+        r"""
+        Toggle mode for data-driven map.
+
+        :param bool collapse: option to collapse outputs to 1-D
+
+        """
+        if iteration is None:
+            iteration = self._iteration
+        self._setup[iteration]['col'] = collapse
+
+    def get_data(self, iteration=None):
+        r"""
+        Formats the indices according to `setup` and then
+        returns relevant data vector for a particular iteration.
+        """
+        if iteration is None:
+            iteration = self._iteration
+
+        if self._output_probability_set is None:
+            inds = np.arange(self._output_sample_set._dim)
+            logging.warning("Returning reference value.")
+            return self._output_sample_set._reference_value[inds]
+        elif self._output_probability_set._reference_value is None:
+            inds = np.arange(self._output_sample_set._dim)
+            if self._output_sample_set._reference_value is not None:
+                return self._output_sample_set._reference_value[inds]
+            else:
+                msg = "Output reference is None. "
+                msg += "Will use mean of observed as reference data!"
+                logging.warning(msg)
+                # Return zeros as placeholder.
+                self.set_data_from_observed(iteration=iteration)
+                return self.get_data(iteration)
+        else:  # (noisy) data is not None
+            inds = self.get_data_indices(iteration)
+            return self._output_probability_set._reference_value[inds]
+
+    def set_data(self, data, std=None, inds=None, iteration=None):
+        r"""
+        Write the reference value to the output probability set.
+        (Bypass the checking of dimension).
+        If you pass a noise level, we will take note of it.
+        If one does not exist, create one to match the dimension.
+        inds = None default is to use all data.
+        """
+        if iteration is None:
+            iteration = self._iteration
+
+        dim = len(data)
+        self._setup[iteration]['ind'] = inds
+        if self._output_probability_set is None:
+            logging.warning("Missing output probability set. Creating.")
+            self._output_probability_set = sample_set(dim)
+
+        if self._output_probability_set._reference_value is None:
+            self._output_probability_set._reference_value = np.copy(data)
+        else:
+            inds = self.get_data_indices(iteration)
+            if len(inds) != dim:
+                msg = 'Indices do not match data length. '
+                msg += 'Overwriting data entirely.'
+                # raise ValueError('Indices do not match data length.')
+                logging.warning(msg)
+                self._output_probability_set.\
+                    _reference_value = np.copy(data)
+            else:
+                self._output_probability_set.\
+                    _reference_value[self.get_data_indices()] = np.copy(data)
+
+        if std is None:
+            if self._setup[iteration]['std'] is None:
+                if self._setup[iteration]['obs'] is None:
+                    logging.warning(
+                        "No way to infer std. Will use sample variance.")
+                    if len(self.get_data_indices(iteration)) == 1:
+                        logging.warning(
+                            "Cannot take sample variance of singleton.")
+                else:
+                    logging.warning(
+                        "No std provided. Will use std from observed.")
+            else:
+                logging.warning(
+                    "No std provided. Using existing entry in setup.")
+        else:
+            self._setup[iteration]['std'] = std
+        if self._setup[iteration]['col']:
+            # clear predicted since we just changed indices, data, or std, all
+            # of which are part of the QoI model definition.
+            self._setup[iteration]['pre'] = None
+
+    def set_indices(self, inds, iteration=None):
+        r"""
+        Whatever is passed is written to `setup`. Clear predicted entry.
+        """
+        if iteration is None:
+            iteration = self._iteration
+        self._setup[iteration]['ind'] = inds
+        self._setup[iteration]['pre'] = None
+        self._setup[iteration]['obs'] = None
+        logging.warning('Observed and Predicted entries cleared.')
+
+    def get_data_indices(self, iteration=None):
+        r"""
+        Reads in value from `setup` and converts it to the proper
+        indices for `output_probability_set`.
+        """
+        if iteration is None:
+            iteration = self._iteration
+        if self._output_probability_set._reference_value is None:
+            if self._output_sample_set._reference_value is None:
+                logging.info(
+                    "Using length of output samples because reference empty.")
+                data_len = self._output_sample_set._dim
+            else:
+                logging.info(
+                    "Using length of output reference because data empty.")
+                data_len = len(self._output_sample_set._reference_value)
+        else:
+            data_len = len(self._output_probability_set._reference_value)
+        return self.format_indices(data_len, self._setup[iteration]['ind'])
+
+    def get_output_indices(self, iteration=None):
+        r"""
+        Reads in value from `setup` and converts it to indices
+        for `output_sample_set`. In the case of repeated observations,
+        if incomplete data is available, use it.
+        """
+        if iteration is None:
+            iteration = self._iteration
+        if self._output_probability_set is not None:
+            if self._output_probability_set._reference_value is not None:
+                data_len = len(self.get_data(iteration))
+            else:
+                data_len = self._output_probability_set._dim
+        else:
+            data_len = self._output_sample_set._dim
+        inds = self.format_indices(data_len, self._setup[iteration]['ind'])
+        rep = self._setup[iteration]['rep']
+        if rep is not False:  # handle repeated observations
+            if isinstance(rep, np.ndarray):
+                rep = list(rep)
+
+            if isinstance(rep, list) or isinstance(rep, tuple):
+                rep_inds = list(np.tile(rep, len(inds) // len(rep)))
+                if len(rep_inds) != len(
+                        inds):  # data available that is unaccounted for
+                    logging.warning(
+                        "Data doesn't divide evenly into repeated indices.")
+                    num_missing = len(inds) % len(rep_inds)
+                    # add "missing" repeated values.
+                    rep_inds.append(rep[:num_missing])
+                inds = rep_inds  # set as output
+            else:  # repeat vector of indices
+                inds = np.ones(len(inds), dtype=int) * rep
+        else:
+            inds = np.arange(data_len)
+        return list(inds)
+
+    def format_indices(self, data_len, inds):
+        r"""
+        Converts entry in the `setup` dictionary into a set of usable
+        indices for the data.
+        """
+        if inds is None:
+            inds = np.arange(data_len)
+        elif isinstance(inds, float):  # first or last n%
+            if inds <= 1.0:
+                if inds > 0:
+                    inds = np.arange(0, int(data_len * inds))
+                elif inds < 0:
+                    inds = np.arange(int(data_len * (1 + inds)), data_len)
+                else:  # inds = 0.0?
+                    raise ValueError("Please specify nonzero index.")
+            else:  # bootstrap if >= 1.0 to create 'larger' dataset
+                inds = np.random.randint(0, data_len, int(data_len * inds))
+        elif isinstance(inds, int):  # first or last n entries
+            if inds < 0:
+                inds = np.arange(data_len + inds, data_len)
+            elif inds > 0:
+                inds = np.arange(0, inds)
+            else:  # inds = 0
+                raise ValueError("Please specify nonzero index.")
+        elif isinstance(inds, tuple):
+            if len(inds) == 1:
+                start = 0
+                stop = data_len
+                by = inds[0]
+            elif len(inds) == 2:
+                start = inds[0]
+                stop = data_len
+                by = inds[1]
+            else:
+                start = inds[0]
+                stop = inds[1]
+                by = inds[2]
+
+            # if floats passed for any args, convert them.
+            if isinstance(start, float):
+                start = int(data_len * start)
+            if isinstance(stop, float):
+                stop = int(data_len * stop)
+            if isinstance(by, float):
+                by = int(data_len * by)
+            if stop < start or by > data_len:
+                raise ValueError(
+                    "Ordering mismatch. Check index specifications.")
+            inds = np.arange(start, stop, by)
+        else:
+            pass  # use lists  and numpy-arrays as-is
+        return list(inds)
+
+    def get_output(self):
+        return self.get_output_sample_set()
+
+    def get_input(self):
+        return self.get_input_sample_set()
+
+    def set_data_from_observed(self, obs='mean',
+                               alpha=0.99,
+                               iteration=None):
+        r"""
+        Perform a draw from the observed distribution.
+
+        :param string obs: Type of draw to take. Choose from
+                 'mean' (default), 'median',
+                 'min'/'max' (pass `alpha`), or
+
+        :param float alpha: If using obs='min'/'max',
+                this represents the confidence level.
+                Default value is 0.99.
+
+        """
+        if iteration is None:
+            iteration = self._iteration
+        obs_dist = self.get_observed_distribution(iteration)
+        if obs == 'mean':
+            data = obs_dist.mean()
+        elif obs == 'median':
+            data = obs_dist.median()
+        elif obs == 'min':
+            data = obs_dist.interval(alpha)[0]
+        elif obs == 'max':
+            data = obs_dist.interval(alpha)[1]
+        std = obs_dist.std()
+        self._setup[iteration]['std'] = std
+
+        if self._output_probability_set._reference_value is None:
+            self._output_probability_set._reference_value = np.copy(data)
+        else:
+            self._output_probability_set._reference_value[self.get_data_indices(
+                iteration)] = np.copy(data)
+
+    def set_data_from_reference(self, iteration=None, dist=None):
+        # goes and grabs the reference output value for a particular iteration
+        # and hits it with a noise model.
+
+        if iteration is None:
+            iteration = self._iteration
+        # since we are accessing output values.
+        inds = self.get_output_indices(iteration)
+
+        if dist is None:
+            logging.warning("Using observed as noise model.")
+            dist = self._setup[iteration]['obs']
+
+        # support repeating data.
+        Q_ref = self._output_sample_set._reference_value
+        direct = False
+        if Q_ref is None:
+            logging.info("Problem with output reference value.")
+            model = self._setup[iteration]['model']
+            lam_ref = self._input_sample_set._reference_value
+            if lam_ref is None:
+                msg = "Missing input reference value."
+                msg += "Using draw directly from observed distribution."
+                logging.warning(msg)
+                direct = True
+            else:
+                if model is None:
+                    if dist is None:
+                        raise AttributeError("Missing model and observed.")
+                    else:
+                        msg = "Missing model, input reference value present."
+                        msg += "Using draw from observed distribution."
+                        logging.warning(msg)
+                        direct = True
+                else:
+                    logging.info("Using model to map input reference value.")
+                    Q_ref = model(lam_ref)[inds]
+        else:  # existing reference is correctly set
+            # support repeated observations using indices. correct length.
+            Q_ref = Q_ref[inds]
+
+        if (np.max(np.abs(dist.mean())) != 0):
+            logging.warning(
+                "Non-homogeneous noise. Using random draw for data.")
+            direct = True
+        if not direct:
+            noise = self._output_probability_set.rvs(dist=dist)
+            Q_ref = Q_ref + noise
+        else:  # if observed distribution is non-homogogenous
+            Q_ref = self._output_probability_set.rvs(dist=dist)
+
+        self._output_probability_set._reference_value = Q_ref
+
+        return Q_ref
+
+    def set_std(self, std=None, iteration=None):
+        if iteration is None:
+            iteration = self._iteration
+        # if None,
+        if std is None:  # nothing passed
+            if self._setup[iteration]['std'] is None:  # nothing written
+                if self._setup[iteration]['obs'] is None:
+                    logging.warning(
+                        "Defaulting to estimating using data sample variance.")
+                else:  # use observed to infer std if it is missing.
+                    logging.warning(
+                        "Inferring standard deviation from observed.")
+                    # method std() belongs to distribution
+        else:  # write as-is if anything except None
+            # but if numpy array, convert to list.
+            if isinstance(std, np.ndarray):
+                std = std.tolist()
+                # if singleton in array, extract it, continue.
+                if len(std) == 1:
+                    std = std[0]
+                else:  # if array is wrong length, raise error.
+                    if len(std) != len(self.get_data_indices(iteration)):
+                        msg = "Wrong size std (mismatch with data indices)."
+                        raise dim_not_matching(msg)
+
+            if not(isinstance(std, int) or isinstance(std, float)):
+                if len(std) != len(self.get_data_indices(iteration)):
+                    if len(std) == 1:
+                        std = std[0]
+                    elif len(std) == self._output_sample_set._dim:
+                        msg = "Wrong size std."
+                        msg = "Assuming these correspond to repeated outputs."
+                        logging.warning(msg)
+                        pass
+                    else:
+                        msg = "Wrong size std (mismatch with data indices)."
+                        raise dim_not_matching(msg)
+
+        self._setup[iteration]['pre'] = None
+        self._setup[self._iteration]['std'] = std
+        # return what will result from setting the std this way.
+        return self.get_std(iteration)
+
+    def get_std(self, iteration=None):
+        if iteration is None:
+            iteration = self._iteration
+        std = self._setup[iteration]['std']
+        if std is None:  # if empty, get observed or estimate
+            if self._setup[iteration]['obs'] is None:
+                logging.info("Using sample variance estimate.")
+                sample_data = self.get_data(iteration)
+                if len(sample_data) == 1:
+                    msg = "Cannot take variance of singeleton.\n"
+                    msg += "Try changing indexes or turn-off data-driven"
+                    raise AttributeError(msg)
+                else:
+                    std = np.std(sample_data)
+            else:
+                logging.info("Using variance from observed.")
+                std = self._setup[iteration]['obs'].std()
+
+        if isinstance(std, int) or isinstance(std, float):
+            inds = self.get_data_indices(iteration)
+            std = np.ones(len(inds)) * std
+        elif isinstance(std, list) or isinstance(std, tuple):
+            if len(std) == self._output_sample_set._dim:
+                std = np.array(std)[self.get_output_indices(iteration)]
+
+        return list(std)
+
+    def data_driven(self, data=None, std=None, inds=None, iteration=None):
+        r"""
+        Requires reference output probability value to work.
+        Understood to mean "data" already polluted with noise.
+        If missing, we attempt to simulate it if a noise model and
+        input reference value are peresent.
+        If a distribution is present in `output_probability_set`, then we
+        perturb the `output_sample_set` reference value and set it as the
+        reference value in `output_probability_set`.
+        passing inds alone can be like bootstrapping if using repeated.
+        """
+        self.set_data_driven(True)
+        self.set_data(data=data, iteration=iteration, std=std, inds=inds)
+
+    def get_setup(self, iteration=None):
+        if iteration is not None:
+            try:
+                return self._setup[iteration]
+            except KeyError:
+                logging.warning("Iteration out of bounds. Returning current.")
+                return self._setup[self._iteration]
+        else:
+            return self._setup[self._iteration]
+
+    def default_setup(self):
+        # check for data-driven with
+        # if not abs(col): ... do normal. if 1, current inds, if -1, all inds.
+        D = {'ind': None,
+             'rep': False,
+             'col': False,
+             'qoi': 'SWE',
+             'std': None,
+             'obs': None,
+             'pre': None,
+             'model': None
+             }
+        try:
+            self._setup[self._iteration] = D
+        except TypeError:
+            self._setup = {0: D}

--- a/bet/sampling/adaptiveSampling.py
+++ b/bet/sampling/adaptiveSampling.py
@@ -15,7 +15,6 @@ import os
 import glob
 import logging
 import numpy as np
-import scipy.io as sio
 import bet.sampling.basicSampling as bsam
 import bet.util as util
 from bet.Comm import comm
@@ -46,10 +45,9 @@ def loadmat(save_file, lb_model=None, hot_start=None, num_chains=None):
         ``kern_old``)
 
     """
-    print(hot_start)
     if hot_start is None:
         hot_start = 1
-   # LOAD FILES
+    # LOAD FILES
     if hot_start == 1:  # HOT START FROM PARTIAL RUN
         if comm.rank == 0:
             logging.info("HOT START from partial run")
@@ -59,15 +57,16 @@ def loadmat(save_file, lb_model=None, hot_start=None, num_chains=None):
         mdat_files = glob.glob(os.path.join(save_dir,
                                             "proc*_{}".format(base_name)))
         if len(mdat_files) > 0:
-            tmp_mdat = sio.loadmat(mdat_files[0])
+            tmp_mdat = sample.loadmat(mdat_files[0])
         else:
-            tmp_mdat = sio.loadmat(save_file)
+            tmp_mdat = sample.loadmat(save_file)
         if num_chains is None:
             num_chains = np.squeeze(tmp_mdat['num_chains'])
-        num_chains_pproc = num_chains / comm.size
+
+        num_chains_pproc = num_chains // comm.size
         if len(mdat_files) == 0:
             logging.info("HOT START using serial file")
-            mdat = sio.loadmat(save_file)
+            mdat = sample.loadmat(save_file)
             if num_chains is None:
                 num_chains = np.squeeze(mdat['num_chains'])
             num_chains_pproc = num_chains // comm.size
@@ -95,7 +94,8 @@ def loadmat(save_file, lb_model=None, hot_start=None, num_chains=None):
             # if the number of processors is the same then set mdat to
             # be the one with the matching processor number (doesn't
             # really matter)
-            disc = sample.load_discretization(mdat_files[comm.rank])
+            disc = sample.load_discretization(save_file)
+            chain_length = disc.check_nums() // num_chains
             kern_old = np.squeeze(tmp_mdat['kern_old'])
             all_step_ratios = np.squeeze(tmp_mdat['step_ratios'])
         elif hot_start == 1 and len(mdat_files) != comm.size:
@@ -104,7 +104,7 @@ def loadmat(save_file, lb_model=None, hot_start=None, num_chains=None):
             # otherwise gather the data from mdat and then scatter
             # among the processors and update mdat
             mdat_files_local = comm.scatter(mdat_files)
-            mdat_local = [sio.loadmat(m) for m in mdat_files_local]
+            mdat_local = [sample.loadmat(m) for m in mdat_files_local]
             disc_local = [sample.load_discretization(m) for m in
                           mdat_files_local]
             mdat_list = comm.allgather(mdat_local)
@@ -147,7 +147,7 @@ def loadmat(save_file, lb_model=None, hot_start=None, num_chains=None):
     if hot_start == 2:  # HOT START FROM COMPLETED RUN:
         if comm.rank == 0:
             logging.info("HOT START from completed run")
-        mdat = sio.loadmat(save_file)
+        mdat = sample.loadmat(save_file)
         if num_chains is None:
             num_chains = np.squeeze(mdat['num_chains'])
         num_chains_pproc = num_chains // comm.size

--- a/bet/util.py
+++ b/bet/util.py
@@ -67,7 +67,7 @@ def get_global_values(array, shape=None):
     Concatenates local arrays into global array using :meth:`np.vstack`.
 
     :param array: Array.
-    :type P_samples: :class:`~numpy.ndarray`
+    :type array: :class:`~numpy.ndarray`
     :rtype: :class:`~numpy.ndarray`
     :returns: array
     """

--- a/examples/compare/comparison.py
+++ b/examples/compare/comparison.py
@@ -9,7 +9,7 @@ uniformly distributed in a hypercube of sidelength ``delta``.
 The hypercube can be in three locations:
 - corner at [0, 0, ..., 0]  in ``unit_bottom_set``
 - centered at [0.5, 0.5, ... 0.5] in ``unit_center_set``
-- corner in [1, 1, ..., 1] in `` unit_top_set``
+- corner in [1, 1, ..., 1] in ``unit_top_set``
 
 and the number of samples will determine the fidelity of the
 approximation since we are using voronoi-cell approximations.

--- a/examples/sensitivity/heatplate/chooseOptQoIs_2d.py
+++ b/examples/sensitivity/heatplate/chooseOptQoIs_2d.py
@@ -30,6 +30,7 @@ minimizing average skewness.
 """
 
 import scipy.io as sio
+import numpy as np
 import bet.sensitivity.gradients as grad
 import bet.sensitivity.chooseQoIs as cqoi
 import bet.Comm as comm

--- a/setup.py
+++ b/setup.py
@@ -11,7 +11,7 @@ except ImportError:
     from distutils.core import setup
 
 setup(name='bet',
-      version='2.2.1',
+      version='2.3.0',
       description='Butler, Estep, Tavener method',
       author='Steven Mattis',
       author_email='steve.a.mattis@gmail.com',
@@ -24,6 +24,6 @@ setup(name='bet',
                 'bet.sensitivity'],
       install_requires=['matplotlib',
                         'pyDOE',
-                        'scipy<=1.2.1',
+                        'scipy',
                         'numpy',
                         'nose'])

--- a/test/test_postProcess/test_postTools.py
+++ b/test/test_postProcess/test_postTools.py
@@ -129,12 +129,12 @@ class Test_PostTools(unittest.TestCase):
         Test :meth:`bet.postProcess.postTools.sort_by_rho`.
         """
         disc = sample.discretization(input_sample_set=self.data,
-				     output_sample_set=self.data.copy())
+                                     output_sample_set=self.data.copy())
         (self.data1, _) = postTools.sort_by_rho(disc)
         self.assertGreater(np.min(self.data1.get_input_sample_set().
                                   get_probabilities()), 0.0)
         nptest.assert_almost_equal(np.sum(self.data1.get_input_sample_set().
-                                   get_probabilities()), 1.0)
+                                          get_probabilities()), 1.0)
 
         (self.data2, _) = postTools.sort_by_rho(self.data)
         self.assertGreater(np.min(self.data2.get_probabilities()), 0.0)

--- a/test/test_sample.py
+++ b/test/test_sample.py
@@ -10,6 +10,7 @@ import bet.sample as sample
 import bet.util as util
 import bet.sampling.basicSampling as bsam
 from bet.Comm import comm, MPI
+import scipy.stats.distributions as dist
 
 #local_path = os.path.join(os.path.dirname(bet.__file__), "/test")
 local_path = ''
@@ -116,7 +117,9 @@ class Test_sample_set(unittest.TestCase):
 
         if comm.size > 1 and not globalize:
             local_file_name = os.path.os.path.join(os.path.dirname(file_name),
-                                                   "proc{}_{}".format(comm.rank, os.path.basename(file_name)))
+                                                   "proc{}_{}".
+                                                   format(comm.rank, os.path.
+                                                          basename(file_name)))
         else:
             local_file_name = file_name
 
@@ -147,7 +150,9 @@ class Test_sample_set(unittest.TestCase):
 
         if comm.size > 1 and not globalize:
             local_file_name = os.path.os.path.join(os.path.dirname(file_name),
-                                                   "proc{}_{}".format(comm.rank, os.path.basename(file_name)))
+                                                   "proc{}_{}".
+                                                   format(comm.rank, os.path.
+                                                          basename(file_name)))
         else:
             local_file_name = file_name
 
@@ -208,7 +213,8 @@ class Test_sample_set(unittest.TestCase):
         nptest.assert_array_equal(self.sam_set._right,
                                   np.repeat([self.domain[:, 1]], self.num, 0))
         nptest.assert_array_equal(self.sam_set._width,
-                                  np.repeat([self.domain[:, 1] - self.domain[:, 0]], self.num, 0))
+                                  np.repeat([self.domain[:, 1] -
+                                             self.domain[:, 0]], self.num, 0))
         o_num = 35
         self.sam_set.update_bounds(o_num)
         nptest.assert_array_equal(self.sam_set._left,
@@ -216,7 +222,8 @@ class Test_sample_set(unittest.TestCase):
         nptest.assert_array_equal(self.sam_set._right,
                                   np.repeat([self.domain[:, 1]], o_num, 0))
         nptest.assert_array_equal(self.sam_set._width,
-                                  np.repeat([self.domain[:, 1] - self.domain[:, 0]], o_num, 0))
+                                  np.repeat([self.domain[:, 1] -
+                                             self.domain[:, 0]], o_num, 0))
 
     def test_update_bounds_local(self):
         """
@@ -227,12 +234,15 @@ class Test_sample_set(unittest.TestCase):
         self.sam_set.update_bounds_local()
         local_size = self.sam_set.get_values_local().shape[0]
         nptest.assert_array_equal(self.sam_set._left_local,
-                                  np.repeat([self.domain[:, 0]], local_size, 0))
+                                  np.repeat([self.domain[:, 0]],
+                                            local_size, 0))
         nptest.assert_array_equal(self.sam_set._right_local,
-                                  np.repeat([self.domain[:, 1]], local_size, 0))
+                                  np.repeat([self.domain[:, 1]],
+                                            local_size, 0))
         nptest.assert_array_equal(self.sam_set._width_local,
-                                  np.repeat([self.domain[:, 1] - self.domain[:, 0]], local_size,
-                                            0))
+                                  np.repeat([self.domain[:, 1] -
+                                             self.domain[:, 0]],
+                                            local_size, 0))
         o_num = 35
         self.sam_set.update_bounds_local(o_num)
         nptest.assert_array_equal(self.sam_set._left_local,
@@ -240,7 +250,8 @@ class Test_sample_set(unittest.TestCase):
         nptest.assert_array_equal(self.sam_set._right_local,
                                   np.repeat([self.domain[:, 1]], o_num, 0))
         nptest.assert_array_equal(self.sam_set._width_local,
-                                  np.repeat([self.domain[:, 1] - self.domain[:, 0]], o_num, 0))
+                                  np.repeat([self.domain[:, 1] -
+                                             self.domain[:, 0]], o_num, 0))
 
     def test_check_dim(self):
         """
@@ -299,7 +310,8 @@ class Test_sample_set(unittest.TestCase):
         local_size = self.sam_set.get_values_local().shape[0]
         self.sam_set.append_values_local(new_values)
         nptest.assert_array_equal(util.fix_dimensions_data(new_values),
-                                  self.sam_set.get_values_local()[local_size::, :])
+                                  self.sam_set.
+                                  get_values_local()[local_size::, :])
 
     def test_get_dim(self):
         """
@@ -420,14 +432,16 @@ class Test_sample_set(unittest.TestCase):
                 current_array = getattr(self.sam_set, array_name + "_local")
                 if current_array is not None:
                     self.assertGreater(getattr(self.sam_set,
-                                               array_name).shape[0], current_array.shape[0])
+                                               array_name).shape[0],
+                                       current_array.shape[0])
                     local_size = current_array.shape[0]
                     num = comm.allreduce(local_size, op=MPI.SUM)
                     self.assertEqual(num, self.num)
                     current_array_global = util.get_global_values(
                         current_array)
                     nptest.assert_array_equal(getattr(self.sam_set,
-                                                      array_name), current_array_global)
+                                                      array_name),
+                                              current_array_global)
                     if array_name is "_values":
                         assert self.sam_set.shape_local() == (local_size,
                                                               self.dim)
@@ -436,7 +450,8 @@ class Test_sample_set(unittest.TestCase):
                 current_array = getattr(self.sam_set, array_name + "_local")
                 if current_array is not None:
                     nptest.assert_array_equal(getattr(self.sam_set,
-                                                      array_name), current_array)
+                                                      array_name),
+                                              current_array)
                     if array_name is "_values":
                         assert self.sam_set.shape_local() == (self.num,
                                                               self.dim)
@@ -461,6 +476,131 @@ class Test_sample_set(unittest.TestCase):
         domain = np.ones((self.dim, 2))
         self.sam_set.set_domain(domain)
         nptest.assert_array_equal(domain, self.sam_set.get_domain())
+
+    def test_distribution_and_domain(self):
+        """
+        Test set/get distribution and domain inference.
+        """
+        domain = np.array([[0, 1] for _ in range(self.dim)])
+        import scipy
+        from scipy.stats.distributions import uniform
+
+        # default behavior is unit hypercube
+        self.sam_set.set_distribution()
+        assert isinstance(self.sam_set.get_distribution(),
+                          scipy.stats.distributions.rv_frozen)
+
+        # set frozen - should be able to interpret dimension.
+        dist = uniform(loc=0, scale=1)
+        self.sam_set.set_distribution(dist)
+        assert isinstance(self.sam_set.get_distribution(),
+                          scipy.stats.distributions.rv_frozen)
+
+        # ensure domain was properly inferred
+        nptest.assert_array_equal(domain, self.sam_set.get_domain())
+        # set continuous and make sure it gets instantiated
+        self.sam_set.set_distribution(uniform)
+        assert isinstance(self.sam_set.get_distribution(),
+                          scipy.stats.distributions.rv_frozen)
+        nptest.assert_array_equal(domain, self.sam_set.get_domain())
+
+        # try another domain
+        new = [1 for _ in range(self.dim)]
+        self.sam_set.set_distribution(uniform(loc=1,
+                                              scale=new))
+        assert isinstance(self.sam_set.get_distribution(),
+                          scipy.stats.distributions.rv_frozen)
+        nptest.assert_array_equal(domain + 1,
+                                  self.sam_set.get_domain())
+        # try another domain and handler.
+        self.sam_set.set_dist(uniform(loc=new,
+                                      scale=0.5))
+        assert isinstance(self.sam_set.get_dist(),
+                          scipy.stats.distributions.rv_frozen)
+        nptest.assert_array_equal(1 + domain * 0.5,
+                                  self.sam_set.get_domain())
+
+        # incorrect dimension should raise error
+        try:
+            self.sam_set.set_distribution(uniform(loc=0,
+                                                  scale=[1, 1, 1, 1]))
+        except sample.dim_not_matching:
+            pass
+
+    def test_generate_samples(self):
+        """
+        Test random sample generation.
+        """
+        # default to uniform hypercube
+        self.sam_set.set_distribution()
+        for num in [1, 10, 50, 100]:
+            self.sam_set.generate_samples(num)
+            assert self.sam_set.check_num() == num
+        from scipy.stats.distributions import uniform
+        # make sure keyword gets passed to continuous distribution.
+        self.sam_set.set_distribution(uniform, loc=2)
+        for num in [1, 10, 50, 100]:
+            self.sam_set.generate_samples(num)
+            assert self.sam_set.check_num() == num
+        # frozen distribution
+        self.sam_set.set_distribution(uniform(loc=2))
+        for num in [1, 10, 50, 100]:
+            self.sam_set.generate_samples(num)
+            assert self.sam_set.check_num() == num
+
+    def test_rvs(self):
+        """
+        Test ability to use rvs generation with correct shape.
+        """
+        # passing continuous distribution => should convert to frozen.
+        from scipy.stats.distributions import uniform
+        x = self.sam_set.rvs(dist=uniform)
+        assert len(x) == 1
+        from scipy.stats.distributions import norm
+        x = self.sam_set.rvs(dist=norm, loc=1)
+        assert len(x) == 1
+        # now test setting using frozen distributions
+        for num in [1, 10, 50, 100]:
+            self.sam_set.set_values(self.sam_set.rvs(num, dist=norm()))
+            assert self.sam_set.check_num() == num
+
+    def test_pdf(self):
+        """
+        Test pdf capabilities
+        """
+        import scipy.stats.distributions as dists
+        self.sam_set.set_dist(dists.norm)
+        self.sam_set.generate_samples(100)
+        x = self.sam_set.get_values()
+        for dst in [dists.norm, dists.uniform]:
+            y = self.sam_set.pdf(x=x, dist=dst(loc=0, scale=1))
+            tru = dst.pdf(x, loc=0, scale=1).prod(axis=1)
+            nptest.assert_array_equal(tru, y)
+
+    def test_cdf(self):
+        """
+        Test cdf capabilities
+        """
+        import scipy.stats.distributions as dists
+        self.sam_set.set_dist(dists.norm)
+        self.sam_set.generate_samples(100)
+        x = self.sam_set.get_values()
+        for dst in [dists.norm, dists.uniform]:
+            tru = dst.cdf(x, loc=1, scale=2).prod(axis=1)
+            z = self.sam_set.cdf(x=x, dist=dst(loc=1, scale=2))
+            nptest.assert_array_equal(tru, z)
+
+    def test_estimate_probabilities_mc(self):
+        """
+        Test MC assumption in probabilities.
+        """
+        import scipy.stats.distributions as dists
+        self.sam_set.set_dist(dists.norm)
+        for num in [1, 10, 50, 100]:
+            self.sam_set.generate_samples(num)
+            self.sam_set.estimate_probabilities_mc()
+            assert len(np.unique(self.sam_set.get_probabilities())) == 1
+            assert self.sam_set.get_probabilities()[0] == 1.0 / num
 
 
 class Test_sample_set_1d(Test_sample_set):
@@ -489,7 +629,8 @@ class Test_discretization_simple(unittest.TestCase):
         self.output_probability_set.set_values(values3)
         self.disc = sample.discretization(input_sample_set=self.input_set,
                                           output_sample_set=self.output_set,
-                                          output_probability_set=self.output_probability_set)
+                                          output_probability_set=self.
+                                          output_probability_set)
 
     def test_check_nums(self):
         """
@@ -504,9 +645,11 @@ class Test_discretization_simple(unittest.TestCase):
         """
         cnum = int(0.5 * self.num)
         disc_clipped = self.disc.clip(cnum)
-        nptest.assert_array_equal(self.disc._input_sample_set._values[0:cnum, :],
+        nptest.assert_array_equal(self.disc._input_sample_set.
+                                  _values[0:cnum, :],
                                   disc_clipped._input_sample_set._values)
-        nptest.assert_array_equal(self.disc._output_sample_set._values[0:cnum, :],
+        nptest.assert_array_equal(self.disc._output_sample_set.
+                                  _values[0:cnum, :],
                                   disc_clipped._output_sample_set._values)
 
     def test_slicing(self):
@@ -517,16 +660,74 @@ class Test_discretization_simple(unittest.TestCase):
             np.ones((self.num, self.dim2)))
         self.disc._input_sample_set.set_jacobians(
             np.ones((self.num, self.dim2, self.dim1)))
+        self.disc._input_sample_set.set_reference_value(
+            np.random.rand(self.dim1))
+        self.disc._output_sample_set.set_reference_value(
+            np.random.rand(self.dim2))
+        self.disc._output_sample_set.set_domain(
+            np.sort(np.random.rand(self.dim2, 2), axis=1))
+        self.disc._input_sample_set.set_domain(
+            np.sort(np.random.rand(self.dim1, 2), axis=1))
 
         disc_new = self.disc.choose_inputs_outputs(inputs=[0, 2], outputs=[0])
-        nptest.assert_array_equal(self.disc._input_sample_set._values[:, [0, 2]],
+        nptest.assert_array_equal(self.disc._input_sample_set.
+                                  _values[:, [0, 2]],
                                   disc_new._input_sample_set._values)
-        nptest.assert_array_equal(self.disc._output_sample_set._values[:, [0]],
+        nptest.assert_array_equal(self.disc._output_sample_set.
+                                  _values[:, [0]],
                                   disc_new._output_sample_set._values)
-        nptest.assert_array_equal(self.disc._output_sample_set._error_estimates[:, [0]],
-                                  disc_new._output_sample_set._error_estimates)
+        nptest.assert_array_equal(self.disc._output_sample_set.
+                                  _error_estimates[:, [0]],
+                                  disc_new._output_sample_set.
+                                  _error_estimates)
         self.assertEqual(
             disc_new._input_sample_set._jacobians.shape, (self.num, 1, 2))
+        nptest.assert_array_equal(
+            disc_new._input_sample_set._reference_value,
+            self.disc._input_sample_set._reference_value[[0, 2]])
+        nptest.assert_array_equal(
+            disc_new._output_sample_set._reference_value,
+            self.disc._output_sample_set._reference_value[0])
+        nptest.assert_array_equal(
+            disc_new._input_sample_set._domain,
+            self.disc._input_sample_set._domain[[0, 2], :])
+        nptest.assert_array_equal(
+            disc_new._output_sample_set._domain,
+            self.disc._output_sample_set._domain[[0], :])
+
+    def test_choose_outputs(self):
+        """
+        Test `bet.sample.discretization.choose_outputs`
+        """
+        self.disc._output_sample_set.set_domain(
+            np.sort(np.random.rand(self.dim2, 2), axis=1))
+        self.disc._output_sample_set.set_reference_value(
+            np.random.rand(self.dim2))
+        self.disc._output_sample_set.set_error_estimates(
+            np.ones((self.num, self.dim2)))
+        self.disc._input_sample_set.set_jacobians(
+            np.ones((self.num, self.dim2, self.dim1)))
+
+        disc_new = self.disc.choose_outputs(outputs=[0])
+        nptest.assert_array_equal(self.disc._input_sample_set.
+                                  _values,
+                                  disc_new._input_sample_set._values)
+        nptest.assert_array_equal(self.disc._output_sample_set.
+                                  _values[:, [0]],
+                                  disc_new._output_sample_set._values)
+        nptest.assert_array_equal(self.disc._output_sample_set.
+                                  _error_estimates[:, [0]],
+                                  disc_new._output_sample_set.
+                                  _error_estimates)
+        nptest.assert_array_equal(
+            disc_new._output_sample_set._domain,
+            self.disc._output_sample_set._domain[[0], :])
+        nptest.assert_array_equal(
+            disc_new._output_sample_set._reference_value,
+            self.disc._output_sample_set._reference_value[0])
+        nptest.assert_array_equal(
+            disc_new._input_sample_set._jacobians,
+            self.disc._input_sample_set._jacobians)
 
     def test_set_io_ptr(self):
         """
@@ -615,6 +816,31 @@ class Test_discretization_simple(unittest.TestCase):
         """
         test_set = sample.sample_set(dim=self.dim2)
         self.disc.set_output_probability_set(test_set)
+        # test with existing values
+        test_set.set_values(np.random.rand(100, self.dim2))
+        self.disc.set_output_probability_set(test_set)
+        # test with emulated
+        self.disc.set_emulated_output_sample_set(test_set)
+        self.disc.set_output_probability_set(test_set)
+        # test without output samples
+        self.disc._output_sample_set = None
+        self.disc._emulated_output_sample_set = None
+        self.disc.set_output_probability_set(test_set)
+        # test error-handling
+        self.disc.set_output_sample_set(test_set)
+        test_set = sample.sample_set(dim=self.dim2 + 1)
+        try:  # catch first possible dim error
+            self.disc.set_output_probability_set(test_set)
+        except sample.dim_not_matching:
+            pass
+        try:  # catch second error
+            test_set = sample.sample_set(dim=self.dim2 + 1)
+            test_set.set_values(np.random.rand(100, self.dim2 + 1))
+            test_set.global_to_local()
+            self.disc.set_data_driven()
+            self.disc.set_output_probability_set(test_set)
+        except sample.dim_not_matching:
+            pass
 
     def test_get_output_probability_set(self):
         """
@@ -628,6 +854,18 @@ class Test_discretization_simple(unittest.TestCase):
         """
         test_set = sample.sample_set(dim=self.dim2)
         self.disc.set_emulated_output_sample_set(test_set)
+        # test without output samples
+        self.disc._output_sample_set = None
+        self.disc._output_probability_set = None
+        self.disc._emulated_output_sample_set = None
+        self.disc.set_emulated_output_sample_set(test_set)
+        # test error-handling
+        self.disc.set_output_sample_set(test_set)
+        test_set = sample.sample_set(dim=self.dim2 + 1)
+        try:  # catch first possible dim error
+            self.disc.set_emulated_output_sample_set(test_set)
+        except sample.dim_not_matching:
+            pass
 
     def test_get_emulated_output_sample_set(self):
         """
@@ -645,7 +883,9 @@ class Test_discretization_simple(unittest.TestCase):
         comm.barrier()
         if comm.size > 1 and not globalize:
             local_file_name = os.path.os.path.join(os.path.dirname(file_name),
-                                                   "proc{}_{}".format(comm.rank, os.path.basename(file_name)))
+                                                   "proc{}_{}".
+                                                   format(comm.rank, os.path.
+                                                          basename(file_name)))
         else:
             local_file_name = file_name
 
@@ -664,21 +904,25 @@ class Test_discretization_simple(unittest.TestCase):
                         sample.sample_set.all_ndarray_names:
                     curr_attr = getattr(curr_set, set_attrname)
                     if curr_attr is not None:
-                        nptest.assert_array_equal(curr_attr, getattr(
-                            curr_set, set_attrname))
+                        nptest.assert_array_equal(curr_attr,
+                                                  getattr(curr_set,
+                                                          set_attrname))
         comm.barrier()
 
         if comm.rank == 0 and globalize:
             os.remove(local_file_name)
         elif not globalize:
             os.remove(local_file_name)
+
+        # run test with globalize=False
         globalize = False
         sample.save_discretization(self.disc, file_name, "TEST", globalize)
         comm.barrier()
         if comm.size > 1 and not globalize:
             local_file_name = os.path.os.path.join(os.path.dirname(file_name),
-                                                   "proc{}_{}".format(comm.rank,
-                                                                      os.path.basename(file_name)))
+                                                   "proc{}_{}".
+                                                   format(comm.rank, os.path.
+                                                          basename(file_name)))
         else:
             local_file_name = file_name
 
@@ -698,7 +942,8 @@ class Test_discretization_simple(unittest.TestCase):
                     curr_attr = getattr(curr_set, set_attrname)
                     if curr_attr is not None:
                         nptest.assert_array_equal(curr_attr,
-                                                  getattr(curr_set, set_attrname))
+                                                  getattr(curr_set,
+                                                          set_attrname))
         comm.barrier()
 
         if comm.rank == 0 and globalize:
@@ -759,7 +1004,9 @@ class Test_discretization_simple(unittest.TestCase):
         emulated_samples = s_set.copy()
         emulated_samples.update_bounds_local(1001)
         emulated_samples.set_values_local(emulated_samples._width_local
-                                          * np.random.random((1001, emulated_samples.get_dim())) +
+                                          * np.random.random((1001,
+                                                              emulated_samples.
+                                                              get_dim())) +
                                           emulated_samples._left_local)
 
         self.disc.set_input_sample_set(s_set)
@@ -807,7 +1054,9 @@ class Test_discretization_simple(unittest.TestCase):
         emulated_samples = s_set.copy()
         emulated_samples.update_bounds_local(1001)
         emulated_samples.set_values_local(emulated_samples._width_local
-                                          * np.random.random((1001, emulated_samples.get_dim())) +
+                                          * np.random.random((1001,
+                                                              emulated_samples.
+                                                              get_dim())) +
                                           emulated_samples._left_local)
 
         self.disc.set_output_sample_set(s_set)
@@ -910,7 +1159,9 @@ class TestEstimateVolumeEmulated(unittest.TestCase):
         emulated_samples = self.s_set.copy()
         emulated_samples.update_bounds_local(1001)
         emulated_samples.set_values_local(emulated_samples._width_local
-                                          * np.random.random((1001, emulated_samples.get_dim())) +
+                                          * np.random.random((1001,
+                                                              emulated_samples.
+                                                              get_dim())) +
                                           emulated_samples._left_local)
         self.s_set.estimate_volume_emulated(emulated_samples)
         self.lam_vol = self.s_set._volumes
@@ -1203,7 +1454,9 @@ class Test_rectangle_sample_set(unittest.TestCase):
 
         if comm.size > 1 and not globalize:
             local_file_name = os.path.os.path.join(os.path.dirname(file_name),
-                                                   "proc{}_{}".format(comm.rank, os.path.basename(file_name)))
+                                                   "proc{}_{}".
+                                                   format(comm.rank, os.path.
+                                                          basename(file_name)))
         else:
             local_file_name = file_name
 
@@ -1233,7 +1486,9 @@ class Test_rectangle_sample_set(unittest.TestCase):
 
         if comm.size > 1 and not globalize:
             local_file_name = os.path.os.path.join(os.path.dirname(file_name),
-                                                   "proc{}_{}".format(comm.rank, os.path.basename(file_name)))
+                                                   "proc{}_{}".
+                                                   format(comm.rank, os.path.
+                                                          basename(file_name)))
         else:
             local_file_name = file_name
 
@@ -1338,7 +1593,9 @@ class Test_ball_sample_set(unittest.TestCase):
         file_name = os.path.join(local_path, 'testfile.mat')
         if comm.size > 1 and not globalize:
             local_file_name = os.path.os.path.join(os.path.dirname(file_name),
-                                                   "proc{}_{}".format(comm.rank, os.path.basename(file_name)))
+                                                   "proc{}_{}".
+                                                   format(comm.rank, os.path.
+                                                          basename(file_name)))
         else:
             local_file_name = file_name
 
@@ -1374,7 +1631,9 @@ class Test_ball_sample_set(unittest.TestCase):
 
         if comm.size > 1 and not globalize:
             local_file_name = os.path.os.path.join(os.path.dirname(file_name),
-                                                   "proc{}_{}".format(comm.rank, os.path.basename(file_name)))
+                                                   "proc{}_{}".
+                                                   format(comm.rank, os.path.
+                                                          basename(file_name)))
         else:
             local_file_name = file_name
 
@@ -1479,7 +1738,9 @@ class Test_cartesian_sample_set(unittest.TestCase):
         file_name = os.path.join(local_path, 'testfile.mat')
         if comm.size > 1 and not globalize:
             local_file_name = os.path.os.path.join(os.path.dirname(file_name),
-                                                   "proc{}_{}".format(comm.rank, os.path.basename(file_name)))
+                                                   "proc{}_{}".
+                                                   format(comm.rank, os.path.
+                                                          basename(file_name)))
         else:
             local_file_name = file_name
 
@@ -1490,7 +1751,9 @@ class Test_cartesian_sample_set(unittest.TestCase):
 
         if comm.size > 1 and not globalize:
             local_file_name = os.path.os.path.join(os.path.dirname(file_name),
-                                                   "proc{}_{}".format(comm.rank, os.path.basename(file_name)))
+                                                   "proc{}_{}".
+                                                   format(comm.rank, os.path.
+                                                          basename(file_name)))
         else:
             local_file_name = file_name
 
@@ -1520,7 +1783,9 @@ class Test_cartesian_sample_set(unittest.TestCase):
 
         if comm.size > 1 and not globalize:
             local_file_name = os.path.os.path.join(os.path.dirname(file_name),
-                                                   "proc{}_{}".format(comm.rank, os.path.basename(file_name)))
+                                                   "proc{}_{}".
+                                                   format(comm.rank, os.path.
+                                                          basename(file_name)))
         else:
             local_file_name = file_name
 
@@ -1586,3 +1851,708 @@ class Test_cartesian_sample_set(unittest.TestCase):
         volumes = self.sam_set.get_volumes()
         nptest.assert_array_almost_equal(volumes[:-1], 1. / self.nprocs)
         assert volumes[-1] == 0
+
+
+class Test_sampling_discretization(unittest.TestCase):
+    r"""
+    Test the sampling-based approach.
+    """
+
+    def setUp(self):
+        self.dim1 = 3
+        self.num = 300
+        self.dim2 = 2
+        values1 = np.random.rand(self.num, self.dim1)
+        values2 = np.random.randn(self.num, self.dim2)
+        self.input_values = values1
+        self.output_values = values2
+        values3 = np.ones((self.num, self.dim2))
+        self.input_set = sample.sample_set(dim=self.dim1)
+        self.output_set = sample.sample_set(dim=self.dim2)
+        self.output_probability_set = sample.sample_set(dim=self.dim2)
+        self.input_set.set_values(values1)
+        self.output_set.set_values(values2)
+        self.output_probability_set.set_values(values3)
+        self.disc = sample.discretization(input_sample_set=self.input_set,
+                                          output_sample_set=self.output_set,
+                                          output_probability_set=self.
+                                          output_probability_set)
+
+    def test_format_indices(self):
+        """
+        Test multitude of index-formatting options.
+        """
+        # Single Float Test
+        a = 0.3
+        b = a - 1
+        n = 50
+        set_inds = self.disc.format_indices  # shortened function handle
+        nptest.assert_array_equal(np.array(set_inds(n, a) +
+                                           set_inds(n, b)),
+                                  np.arange(n))
+
+        # Integer Test
+        nptest.assert_array_equal(np.array(set_inds(n, int(a * n)) +
+                                           set_inds(n, int(b * n))),
+                                  np.arange(n))
+
+        # List Test
+        nptest.assert_array_equal(np.array(set_inds(n, np.arange(n))),
+                                  np.arange(n))
+        nptest.assert_array_equal(np.array(set_inds(n, list(np.arange(n)))),
+                                  np.arange(n))
+
+        # Tuple Test(s)
+        for i in range(1, n):
+            nptest.assert_array_equal(np.array(set_inds(n + 1, (i,))),
+                                      np.arange(0, n + 1, i))
+            nptest.assert_array_equal(np.array(set_inds(n, None)),
+                                      np.arange(n))
+            nptest.assert_array_equal(np.array(set_inds(n, (i, 1))),
+                                      np.arange(n)[i::])
+            nptest.assert_array_equal(np.array(set_inds(n, (i, 2))),
+                                      np.arange(n)[np.arange(i, n, 2)])
+            nptest.assert_array_equal(np.array(set_inds(n, (i, 1.0, 3))),
+                                      np.arange(n)[np.arange(i, n, 3)])
+            nptest.assert_array_equal(np.array(set_inds(n, (i, n, 1))),
+                                      np.arange(n)[i::])
+            nptest.assert_array_equal(np.array(set_inds(n, (i, n, 2))),
+                                      np.arange(n)[np.arange(i, n, 2)])
+            nptest.assert_array_equal(np.array(set_inds(n, (i, n, 0.2))),
+                                      np.arange(n)[np.arange(i, n,
+                                                             int(0.2 * n))])
+            nptest.assert_array_equal(np.array(set_inds(n, (0, 0.2, i))),
+                                      np.arange(n)[np.arange(0,
+                                                             int(0.2 * n), i)])
+            nptest.assert_array_equal(np.array(set_inds(n, (1, 0.2, i))),
+                                      np.arange(n)[np.arange(1,
+                                                             int(0.2 * n), i)])
+            nptest.assert_array_equal(np.array(set_inds(n, (0.2, 1.0, 1))),
+                                      np.arange(n)[np.arange(int(0.2 * n),
+                                                             n, 1)])
+            nptest.assert_array_equal(np.array(set_inds(n, (0.2, n, 2))),
+                                      np.arange(n)[np.arange(int(0.2 * n),
+                                                             n, 2)])
+
+    def test_empty_problem(self):
+        """
+        Test problem setup syntaxes.
+        """
+        D = self.disc
+
+        def mymodel(input_values):
+            try:
+                return 2 * input_values[:, np.arange(self.dim2) % self.dim1]
+            except IndexError:  # handle 1-d arrays (for reference vals)
+                return 2 * input_values[np.arange(self.dim2) % self.dim1]
+
+        D.set_model(mymodel)
+        D.set_initial()  # uniform [0,1]
+        # D.set_observed(dist.norm())  # set_output_probability_set [TK - fix]
+        # D.get_output().set_reference_value(2*np.ones(self.dim2))  # only for
+        # size inference?
+        D.set_observed()
+        D.set_data_from_observed()
+        # nptest.assert_array_equal(D.get_data(), 2)
+        # D.set_predicted()  # should be optional...
+
+        # evaluate on existing samples
+        D.updated_pdf()
+        D.initial_pdf()
+        D.observed_pdf()
+        D.predicted_pdf()
+
+        # evaluate at a given set of points
+        D.initial_pdf(self.input_values)
+        D.updated_pdf(self.input_values)
+        D.observed_pdf(self.output_values)
+        D.predicted_pdf(self.output_values)
+
+    def test_set_observed_rv_continuous(self):
+        """
+        Test default behavior of set_observed.
+        """
+        D = self.disc
+        D.set_observed(dist.norm)
+        D.set_data_from_observed()
+        nptest.assert_array_equal(D.get_data(), 0)
+        D.observed_pdf()
+        D.set_data_driven_mode('SSE')
+        D.observed_pdf()
+        D.set_data_driven_mode('MSE')
+
+    def test_set_observed_rv_frozen(self):
+        """
+        Test default behavior of set_observed with frozen dist.
+        """
+        D = self.disc
+        D.set_observed(dist.norm(loc=2 * np.ones(self.dim2)))
+        D.set_data_from_observed()
+        nptest.assert_array_equal(D.get_data(), 2)
+
+    def test_solve_problem(self):
+        """
+        Solve inverse problem (input dim == output dim)
+        """
+        D = self.disc
+
+        def mymodel(input_values):
+            try:
+                return 2 * input_values[:, np.arange(self.dim2) % self.dim1]
+            except IndexError:  # handle 1-d arrays (for reference vals)
+                return 2 * input_values[np.arange(self.dim2) % self.dim1]
+
+        D.set_model(mymodel)
+        D.set_initial(dist.uniform(loc=[0] * self.dim1,
+                                   scale=[1] * self.dim1))  # uniform [0,1]
+        # set_output_probability_set
+        D.set_observed(dist.uniform(loc=[0.5] * self.dim2,
+                                    scale=[1] * self.dim2))
+        D.set_predicted(dist.uniform(loc=[0] * self.dim2,
+                                     scale=[2] * self.dim2))
+
+        updated_pdf = D.updated_pdf()
+
+        # check that correct samples received positive probability
+        pos_vals = D.get_input_values()[updated_pdf > 0, :]
+        nptest.assert_array_equal(pos_vals[:, :self.dim2] < 0.75, True)
+        nptest.assert_array_equal(
+            pos_vals[:, :self.dim2] > 0.25, True)  # greater than
+        # check validity of solution against (simple-function) analytical one
+        assert np.max(updated_pdf[updated_pdf > 0] - 2**self.dim1) < 1E-14
+        D.mud_index()
+        D.mud_point()
+
+    def test_set_observed_no_reference(self):
+        """
+        Test how observed behaves without reference output.
+        """
+        D = self.disc
+        for l in [1, 2, 3]:
+            D.set_observed(loc=l)  # infer dimension correctly
+            D.get_data()
+            assert np.linalg.norm(np.array(D.get_std()) - 1) == 0
+        for s in [1, 2, 3]:
+            D.set_observed(scale=s)  # infer dimension correctly
+            D.get_data()
+            assert np.linalg.norm(np.array(D.get_std()) - s) == 0
+
+    def test_get_std_from_obs(self):
+        """
+        Test inferring std from observed distribution.
+        """
+        D = self.disc
+        for l in [1, 2, 3]:
+            D.set_observed(scale=l)  # infer dimension correctly
+            D._setup[0]['std'] = None
+            assert np.linalg.norm(np.array(D.get_std()) - l) == 0
+
+    def test_set_data(self):
+        """
+        Test straight-forward data-setting.
+        """
+        D = self.disc.copy()
+        ref_val = 21 * np.random.rand(self.dim2)
+        # set manually
+        D._output_probability_set._reference_value = np.copy(ref_val)
+        nptest.assert_array_equal(D.get_data(), ref_val)
+        D = self.disc.copy()
+        # set using function
+        D.set_data(ref_val)
+        nptest.assert_array_equal(D.get_data(), ref_val)
+        # inherit std from observed
+        D.set_observed()
+        nptest.assert_array_equal(D.get_std(), np.ones(self.dim2))
+        # test perturbation in-place
+        D._output_probability_set._reference_value += 1
+        nptest.assert_array_equal(D.get_data(), ref_val + 1)
+        # test inferring std from data
+        if self.dim2 > 1:
+            D._setup[0]['std'] = None
+            D._setup[0]['obs'] = None
+            assert np.linalg.norm(np.array(D.get_std()) -
+                                  D.get_data().std()) == 0
+            # change data
+            D.set_data(1 + 2 * ref_val)
+            assert np.linalg.norm(np.array(D.get_std()) -
+                                  D.get_data().std()) == 0
+
+    def test_set_data_from_observed(self):
+        """
+        Test using mean/median/bound of observed as data.
+        """
+        D = self.disc
+        D.set_observed()
+
+        a, b = 1, 2
+        loc, scale = np.zeros(self.dim2), np.ones(self.dim2)
+
+        obs_dist = dist.beta(a=a, b=b, loc=loc, scale=scale)
+        D.set_observed(obs_dist)
+        # take draw from distribution
+        D.set_data_from_observed()
+        nptest.assert_array_equal(obs_dist.mean() -
+                                  D.get_data(), 0)
+        D.set_data_from_observed('mean')
+        nptest.assert_array_equal(obs_dist.mean() -
+                                  D.get_data(), 0)
+        D.set_data_from_observed('median')
+        nptest.assert_array_equal(obs_dist.median() -
+                                  D.get_data(), 0)
+        # interval around mean value using our keywords: min/max
+        D.set_data_from_observed('min')
+        nptest.assert_array_equal(obs_dist.interval(0.99)[0] -
+                                  D.get_data(), 0)
+        D.set_data_from_observed('min', alpha=0.15)
+        nptest.assert_array_equal(obs_dist.interval(0.15)[0] -
+                                  D.get_data(), 0)
+        D.set_data_from_observed('max')
+        nptest.assert_array_equal(obs_dist.interval(0.99)[1] -
+                                  D.get_data(), 0)
+        D.set_data_from_observed('max', alpha=0.25)
+        nptest.assert_array_equal(obs_dist.interval(0.25)[1] -
+                                  D.get_data(), 0)
+
+    def test_set_data_from_reference(self):
+        """
+        Test using reference and observed to perturb
+        """
+        D = self.disc
+        ref_val = np.ones(self.dim2)
+        D._output_sample_set.set_reference_value(ref_val)
+
+        std = 0.1
+        noise_dist = dist.norm(loc=0, scale=std)
+
+        D.set_noise_model(noise_dist)
+        D.set_data_from_reference()
+
+        assert np.max(np.abs(D.get_data() - ref_val)) < std * 6
+
+        # should be able to pass scalar values and have normal assumption
+        D.set_noise_model(std * 2)  # double error level
+        D.set_data_from_reference()
+        assert np.max(np.abs(D.get_data() - ref_val)) < std * 12
+
+        if D._setup[0]['model'] is not None:
+            # recover missing output reference if input present.
+            D._input_sample_set.set_reference_value(ref_val / 2)
+            D._output_sample_set._reference_value = None
+            D.set_noise_model(std / 2)  # half error level
+            D.set_data_from_reference()
+            assert np.max(np.abs(D.get_data() - ref_val)) < std * 3
+
+        # use draw directly from observed if reference is empty
+        D._input_sample_set._reference_value = None
+        D._output_sample_set._reference_value = None
+        D.set_noise_model(std / 2)  # half error level
+        D.set_data_from_reference()
+        assert np.max(np.abs(D.get_data())) < std * 3
+
+    def test_set_initial_no_model(self):
+        """
+        Test setting initial without model.
+        """
+        import scipy.stats as sstats
+        D = self.disc
+        D.set_initial(dist.norm)
+        assert isinstance(D.get_initial().dist,
+                          sstats._continuous_distns.norm_gen)
+        assert D.get_output_values().size == 0
+        # test that re-setting initial works as expected (deletes output
+        # values)
+        D.set_initial(dist.uniform)
+        assert D.get_output_values().size == 0
+        assert isinstance(D.get_initial().dist,
+                          sstats._continuous_distns.uniform_gen)
+        D.set_initial(dist.norm(loc=np.zeros(self.dim1)))
+        assert D.get_output_values().size == 0
+        assert isinstance(D.get_initial().dist,
+                          sstats._continuous_distns.norm_gen)
+        D.get_input().set_reference_value(np.ones(self.dim1))
+        D.set_initial(dist.norm(loc=np.zeros(self.dim1)))
+        assert D.get_output_values().size == 0
+        # test that this syntax works
+        D.get_initial_distribution()
+
+    def test_set_initial_with_model(self):
+        """
+        Test setting initial with model.
+        """
+        import scipy.stats as sstats
+        D = self.disc
+        # set model
+        for dim in range(1, 5):
+            self.dim2 = dim
+
+            def mymodel(input_values):
+                try:
+                    return 2 * input_values[:, np.arange(dim) % self.dim1]
+                except IndexError:  # handle 1-d arrays (for reference vals)
+                    return 2 * input_values[np.arange(dim) % self.dim1]
+
+            D.set_model(mymodel)
+            D.set_initial(dist.norm)
+            assert isinstance(D.get_initial_distribution().dist,
+                              sstats._continuous_distns.norm_gen)
+            # set_output_probability_set
+            assert D.get_output_values().shape == (self.num, dim)
+            # test that re-setting initial works as expected (deletes output
+            # values)
+            D.set_initial(dist.uniform)
+            assert D.get_output_values().size == self.num * dim
+            assert isinstance(D.get_initial().dist,
+                              sstats._continuous_distns.uniform_gen)
+            D.set_initial(dist.norm(loc=np.zeros(self.dim1)))
+            assert D.get_output_values().shape == (self.num, dim)
+            assert isinstance(D.get_initial().dist,
+                              sstats._continuous_distns.norm_gen)
+            D.get_input().set_reference_value(np.ones(self.dim1))
+            D.set_initial(dist.norm(loc=np.zeros(self.dim1)))
+            assert D.get_output_values().shape == (self.num, dim)
+            assert D.get_output_values().size == self.num * dim
+
+    def test_set_observed(self):
+        """
+        Test setting observed.
+        """
+        import scipy.stats as sstats
+        D = self.disc
+        D.set_observed(dist.norm(loc=np.arange(self.dim2)))
+        assert isinstance(D.get_observed().dist,
+                          sstats._continuous_distns.norm_gen)
+        try:
+            D.set_output_probability_set(None)
+        except AttributeError:
+            pass
+        D._output_probability_set = None
+        D.set_observed(dist.uniform(loc=np.arange(self.dim2)))
+        assert isinstance(D.get_observed().dist,
+                          sstats._continuous_distns.uniform_gen)
+
+    def test_set_predicted(self):
+        """
+        Test setting predicted.
+        """
+        import scipy.stats as sstats
+        from scipy.stats import gaussian_kde as gkde
+        D = self.disc
+        num = 21
+
+        def mymodel(input_values):
+            try:
+                return 2 * input_values[:, np.arange(self.dim2) % self.dim1]
+            except IndexError:  # handle 1-d arrays (for reference vals)
+                return 2 * input_values[np.arange(self.dim2) % self.dim1]
+
+        D.set_model(mymodel)
+        D.set_initial(num=num)
+        assert D.check_nums() == num
+        D.set_predicted()
+        assert isinstance(D.get_predicted(), gkde)
+        D.set_predicted(dist.uniform(loc=0, scale=1))
+        assert isinstance(D.get_predicted().dist,
+                          sstats._continuous_distns.uniform_gen)
+
+    def test_set_std(self):
+        """
+        Test set/get for standard deviation parameter.
+        """
+        D = self.disc
+        D.set_data(np.ones(self.dim2))
+        D.set_std(0.1)
+        nptest.assert_array_equal(D.get_std(), 0.1 * np.ones(self.dim2))
+        # make sure vector of correct length works
+        vec = np.random.rand(self.dim2)
+        D.set_std(vec)
+        nptest.assert_array_equal(D.get_std(), vec)
+        vec = np.random.rand(self.dim2 - 1)
+        try:  # should throw dim_not_matching error.
+            D.set_std(vec)
+            assert len(D.get_std()) == self.dim2
+        except sample.dim_not_matching:
+            pass
+
+    def test_likelihood(self):
+        """
+        Test likelihood function in default mode.
+        """
+        D = self.disc
+
+        def mymodel(input_values):
+            try:
+                return 2 * input_values[:, np.arange(self.dim2) % self.dim1]
+            except IndexError:  # handle 1-d arrays (for reference vals)
+                return 2 * input_values[np.arange(self.dim2) % self.dim1]
+
+        D.set_model(mymodel)
+        D.set_initial(dist.uniform(loc=[0] * self.dim1,
+                                   scale=[1] * self.dim1))  # uniform [0,1]
+        D.set_observed(dist.norm(loc=[0.5] * self.dim2,
+                                 scale=[0.1] * self.dim2))
+        D.set_predicted(dist.uniform(loc=[0] * self.dim2,
+                                     scale=[2] * self.dim2))
+        mud_point = D.mud_point()
+        D.set_likelihood()
+        map_point = D.map_point()
+        assert np.linalg.norm(mud_point - map_point) / \
+            np.linalg.norm(map_point) < 0.05
+        # nptest.assert_array_equal(mud_point, map_point)
+
+    def test_shorthand(self):
+        """
+        Test short-hand versions of methods.
+        """
+        assert self.disc.get_input() == self.disc.get_input_sample_set()
+        assert self.disc.get_output() == self.disc.get_output_sample_set()
+
+    def test_set_data_driven_mode(self):
+        """
+        Test data-driven functional setting.
+        """
+        D = self.disc
+        for mode in ['SSE', 'MSE', 'SWE']:
+            D.set_data_driven_mode(mode)
+            assert D.get_setup()['qoi'] == mode
+        # test error-catching
+        try:
+            D.set_data_driven('FAKE')
+        except ValueError:
+            pass
+
+    def test_set_data_driven_status(self):
+        """
+        Test data-driven mode options.
+        """
+        D = self.disc
+        D.set_data_driven()
+        # test toggling modes
+        assert D.get_setup(0)['col'] is True
+        D.set_data_driven(False)
+        assert D.get_setup(0)['col'] is False
+        # test inheriting mode
+        D.iterate()
+        assert D.get_setup()['col'] is False
+        # change current mode
+        D.set_data_driven()
+        assert D.get_setup()['col'] is True
+        # change previous mode
+        D.set_data_driven(True, iteration=0)
+        assert D.get_setup(0)['col'] is True
+
+    # def test_set_initial_densities(self):
+    #     """
+    #     TK - fix this test.
+    #     """
+    #     self.disc.set_initial_densities()
+
+
+class Test_sampling_one_dim(Test_sampling_discretization):
+    def setUp(self):
+        self.dim1 = 1
+        self.num = 100
+        self.dim2 = 1
+        values1 = np.random.rand(self.num, self.dim1)
+        values2 = np.random.randn(self.num, self.dim2)
+        self.input_values = values1
+        self.output_values = values2
+        values3 = np.ones((self.num, self.dim2))
+        self.input_set = sample.sample_set(dim=self.dim1)
+        self.output_set = sample.sample_set(dim=self.dim2)
+        self.output_probability_set = sample.sample_set(dim=self.dim2)
+        self.input_set.set_values(values1)
+        self.output_set.set_values(values2)
+        self.output_probability_set.set_values(values3)
+        self.disc = sample.discretization(input_sample_set=self.input_set,
+                                          output_sample_set=self.output_set,
+                                          output_probability_set=self.
+                                          output_probability_set)
+
+
+class Test_sampling_data_driven(Test_sampling_discretization):
+    """
+    If the pushforward is constant, MUD/MAP must match if there
+    is only a single observation.
+    """
+
+    def setUp(self):
+        self.dim1 = 1
+        self.num = 101
+        self.dim2 = 1
+        # values1 = np.random.rand(self.num, self.dim1)
+        values1 = np.linspace(0, 1, self.num).reshape(-1, 1)
+
+        def mymodel(input_values):
+            try:
+                return 2 * input_values[:, np.arange(self.dim2) % self.dim1]
+            except IndexError:  # handle 1-d arrays (for reference vals)
+                return 2 * input_values[np.arange(self.dim2) % self.dim1]
+        values2 = mymodel(values1)
+
+        self.input_values = values1
+        self.output_values = values2
+        values3 = np.ones((self.num, self.dim2))
+        self.input_set = sample.sample_set(dim=self.dim1)
+        self.output_set = sample.sample_set(dim=self.dim2)
+        self.input_set.set_values(values1)
+        self.output_set.set_values(values2)
+        self.disc = sample.discretization(input_sample_set=self.input_set,
+                                          output_sample_set=self.output_set)
+
+        self.disc.set_initial(dist.uniform(loc=[0] * self.dim1,
+                                           scale=[1] * self.dim1), gen=False)
+
+        self.model = mymodel
+        self.disc.set_data_driven()
+        self.std = 0.01
+
+        true_value = np.array([0.5] * self.dim1)
+        self.ans = true_value
+        target_noise = self.std * np.random.randn(self.dim2)
+        true_target = mymodel(true_value)
+        target = true_target + target_noise
+        self.disc.set_data(target, std=self.std)
+
+    def test_solve_problem(self):
+        """
+        Solve inverse problem (input dim != output dim)
+        """
+        D = self.disc
+        mymodel = self.model
+
+        D.set_model(mymodel)
+        # make sure this function can be called.
+        updated_pdf = D.updated_pdf()
+
+        # check that correct samples received positive probability
+        expected = 0.005 * updated_pdf.max()
+        # get relatively high probability samples
+        pos_vals = D.get_input_values()[updated_pdf > expected, :]
+        # ensure they are within 3 std deviations of true value
+        nptest.assert_array_equal(pos_vals < self.ans + self.std * 3, True)
+        nptest.assert_array_equal(pos_vals > self.ans - self.std * 3, True)
+        # check validity of solution against # TK - SOMETIMES FAILS
+        assert np.linalg.norm(D.mud_point() - self.ans) <= 1E-2 + 1E-6
+
+    def test_set_predicted(self):
+        """
+        Test setting predicted.
+        """
+        import scipy.stats as sstats
+        from scipy.stats import gaussian_kde as gkde
+        D = self.disc
+        num = 21
+        mymodel = self.model
+
+        D.set_model(mymodel)
+        D.set_initial(num=num)
+        assert D.check_nums() == num
+        D.set_predicted()
+        assert isinstance(D.get_predicted(), gkde)
+        D.set_predicted(dist.uniform(loc=0, scale=2))
+        assert isinstance(D.get_predicted().dist,
+                          sstats._continuous_distns.uniform_gen)
+
+    def test_likelihood(self):
+        """
+        Test likelihood function with data-driven.
+        """
+        D = self.disc
+        mymodel = self.model
+
+        D.set_model(mymodel)
+
+        D.set_predicted()
+
+        mud_point = D.mud_point()
+        # set_output_probability_set
+        # D.set_observed(scale=[self.std] * self.dim2)
+        D.set_noise_model(self.std)  # is this necessary?
+        D.set_likelihood()
+        map_point = D.map_point()
+        # nptest.assert_array_almost_equal(mud_point, map_point, 2)
+        assert np.linalg.norm(mud_point - map_point) / \
+            np.linalg.norm(map_point) < 0.05
+
+
+class Test_sampling_data_driven_alt(Test_sampling_data_driven):
+    """
+    With enough data points, we should get the same solution
+    despite havin more error in observations.
+    """
+
+    def setUp(self):
+        self.dim1 = 1
+        self.num = 200
+        self.dim2 = 50
+        # values1 = np.random.rand(self.num, self.dim1)
+        values1 = np.linspace(0, 1, self.num).reshape(-1, 1)
+
+        def mymodel(input_values):
+            try:
+                return 2 * input_values[:, np.arange(self.dim2) % self.dim1]
+            except IndexError:  # handle 1-d arrays (for reference vals)
+                return 2 * input_values[np.arange(self.dim2) % self.dim1]
+        values2 = mymodel(values1)
+
+        self.input_values = values1
+        self.output_values = values2
+        values3 = np.ones((self.num, self.dim2))
+        self.input_set = sample.sample_set(dim=self.dim1)
+        self.output_set = sample.sample_set(dim=self.dim2)
+        self.input_set.set_values(values1)
+        self.output_set.set_values(values2)
+        self.disc = sample.discretization(input_sample_set=self.input_set,
+                                          output_sample_set=self.output_set)
+
+        self.disc.set_initial(dist.uniform(loc=[0] * self.dim1,
+                                           scale=[1] * self.dim1), gen=False)
+
+        self.model = mymodel
+        self.disc.set_data_driven()
+        self.std = 0.05
+
+        true_value = np.array([0.5] * self.dim1)
+        self.ans = true_value
+        target_noise = self.std * np.random.randn(self.dim2)
+        true_target = mymodel(true_value)
+        target = true_target + target_noise
+        self.disc.set_data(target, std=self.std)
+
+
+class Test_sampling_repeated(Test_sampling_data_driven):
+    def setUp(self):
+        self.dim1 = 1
+        self.num = 300
+        self.dim2 = 1
+        self.num_obs = 50
+        # values1 = np.random.rand(self.num, self.dim1)
+        values1 = np.linspace(0, 1, self.num).reshape(-1, 1)
+
+        def mymodel(input_values):
+            return 2 * input_values
+        values2 = mymodel(values1)
+        self.input_values = values1
+        self.output_values = values2
+        values3 = np.ones((self.num, self.dim2))
+        self.input_set = sample.sample_set(dim=self.dim1)
+        self.output_set = sample.sample_set(dim=self.dim1)
+        self.input_set.set_values(values1)
+        self.output_set.set_values(values2)
+        self.disc = sample.discretization(input_sample_set=self.input_set,
+                                          output_sample_set=self.output_set)
+
+        self.disc.set_initial(dist.uniform(loc=[0] * self.dim1,
+                                           scale=[1] * self.dim1), gen=False)
+
+        self.model = mymodel
+        self.disc.set_data_driven()
+        self.std = 0.05
+
+        true_value = np.array([0.5])
+        self.ans = true_value
+        target_noise = self.std * np.random.randn(self.num_obs)
+        true_target = mymodel(true_value)
+        target = true_target + target_noise
+        self.disc.set_data(target, std=self.std)
+        self.disc.set_repeated()

--- a/test/test_sampling/test_adaptiveSampling.py
+++ b/test/test_sampling/test_adaptiveSampling.py
@@ -11,7 +11,6 @@ import glob
 import numpy.testing as nptest
 import numpy as np
 import bet.sampling.adaptiveSampling as asam
-import scipy.io as sio
 from bet.Comm import comm
 import bet
 import bet.sample
@@ -59,8 +58,8 @@ def test_loadmat_init():
     mdat2['kern_old'] = np.random.random((num_chains2,))
     mdat2['step_ratios'] = np.random.random((num_samples2,))
 
-    sio.savemat(os.path.join(local_path, 'testfile1'), mdat1)
-    sio.savemat(os.path.join(local_path, 'testfile2'), mdat2)
+    bet.sample.savemat(os.path.join(local_path, 'testfile1'), mdat1)
+    bet.sample.savemat(os.path.join(local_path, 'testfile2'), mdat2)
 
     bet.sample.save_discretization(disc(my_input1, my_output1),
                                    os.path.join(local_path, 'testfile1'), globalize=True)
@@ -173,15 +172,17 @@ def verify_samples(QoI_range, sampler, input_domain,
     comm.barrier()
     mdat = dict()
     # if comm.rank == 0:
-    mdat = sio.loadmat(savefile)
+    mdat = bet.sample.loadmat(savefile)
     saved_disc = bet.sample.load_discretization(savefile)
     saved_disc.local_to_global()
 
     # # compare the input
-    nptest.assert_array_equal(my_discretization._input_sample_set.get_values(),
+    nptest.assert_array_equal(my_discretization._input_sample_set.
+                              get_values(),
                               saved_disc._input_sample_set.get_values())
     # compare the output
-    nptest.assert_array_equal(my_discretization._output_sample_set.get_values(),
+    nptest.assert_array_equal(my_discretization._output_sample_set.
+                              get_values(),
                               saved_disc._output_sample_set.get_values())
 
     nptest.assert_array_equal(all_step_ratios, mdat['step_ratios'])
@@ -418,9 +419,9 @@ class Test_adaptive_sampler(unittest.TestCase):
             """
             Indicator function
             """
-            inside = np.logical_and(np.all(np.greater_equal(outputs,
-                                                            Q_ref - .5 * bin_size), axis=1), np.all(np.less_equal(outputs,
-                                                                                                                  Q_ref + .5 * bin_size), axis=1))
+            bs = .5 * bin_size
+            inside = np.logical_and(np.all(np.greater_equal(outputs, Q_ref - bs), axis=1),
+                                    np.all(np.less_equal(outputs, Q_ref + bs), axis=1))
             max_values = np.repeat(maximum, outputs.shape[0], 0)
             return inside.astype('float64') * max_values
 
@@ -467,7 +468,7 @@ class Test_adaptive_sampler(unittest.TestCase):
         for _, QoI_range, sampler, input_domain, savefile in self.test_list:
             for initial_sample_type in ["random", "r", "lhs"]:
                 print("Initial sample type: %s" % (initial_sample_type))
-                for hot_start in range(3):
+                for hot_start in range(2):
                     verify_samples(QoI_range, sampler, input_domain,
                                    t_set, savefile, initial_sample_type, hot_start)
 

--- a/test/test_sampling/test_basicSampling.py
+++ b/test/test_sampling/test_basicSampling.py
@@ -9,7 +9,6 @@ import os
 import pyDOE
 import numpy.testing as nptest
 import numpy as np
-import scipy.io as sio
 import bet
 import bet.sampling.basicSampling as bsam
 from bet.Comm import comm
@@ -38,8 +37,8 @@ def test_loadmat():
     my_input2 = sample_set(1)
     my_input2.set_values(np.random.random((6, 1)))
 
-    sio.savemat(os.path.join(local_path, 'testfile1'), mdat1)
-    sio.savemat(os.path.join(local_path, 'testfile2'), mdat2)
+    bet.sample.savemat(os.path.join(local_path, 'testfile1'), mdat1)
+    bet.sample.savemat(os.path.join(local_path, 'testfile2'), mdat2)
 
     bet.sample.save_discretization(disc(my_input1, my_output),
                                    (os.path.join(local_path, 'testfile1')), globalize=True)
@@ -104,8 +103,8 @@ def test_loadmat_parallel():
         local_file_name1 = file_name1
         local_file_name2 = file_name2
 
-    sio.savemat(local_file_name1, mdat1)
-    sio.savemat(local_file_name2, mdat2)
+    bet.sample.savemat(local_file_name1, mdat1)
+    bet.sample.savemat(local_file_name2, mdat2)
     comm.barrier()
 
     bet.sample.save_discretization(disc(my_input1, my_output1),
@@ -173,7 +172,7 @@ def verify_compute_QoI_and_create_discretization(model, sampler,
 
     # did the file get correctly saved?
     saved_disc = bet.sample.load_discretization(savefile)
-    mdat = sio.loadmat(savefile)
+    mdat = bet.sample.loadmat(savefile)
     print("HERE HERE", mdat, my_num)
     # comm.barrier()
     # compare the samples
@@ -184,7 +183,129 @@ def verify_compute_QoI_and_create_discretization(model, sampler,
                               saved_disc._output_sample_set.get_values())
 
 
-def verify_create_random_discretization(model, sampler, sample_type, input_domain,
+def verify_add_qoi(model, sampler,
+                   input_sample_set,
+                   savefile):
+    """
+    Verify that the user samples are correct.
+    """
+    # evalulate the model at the samples directly
+    output_values = (np.column_stack([model(input_sample_set._values),
+                                      model(input_sample_set._values)]))
+
+    if len(output_values.shape) == 1:
+        output_sample_set = sample_set(1)
+    else:
+        output_sample_set = sample_set(output_values.shape[1])
+    output_sample_set.set_values(output_values)
+    discretization = disc(input_sample_set, output_sample_set)
+
+    # evaluate the model at the sample
+    print(savefile, input_sample_set.get_dim())
+    my_discretization = sampler.compute_QoI_and_create_discretization(
+        input_sample_set, savefile, globalize=True)
+    # check add_qoi
+    my_discretization = sampler.add_qoi(my_discretization,
+                                        savefile=savefile, globalize=True)
+    # comm.barrier()
+
+    my_num = my_discretization.check_nums()
+
+    # compare the samples
+    nptest.assert_array_equal(my_discretization._input_sample_set.get_values(),
+                              discretization._input_sample_set.get_values())
+    # compare the data
+    nptest.assert_array_equal(my_discretization._output_sample_set.get_values(),
+                              discretization._output_sample_set.get_values())
+
+    # did num_samples get updated?
+    assert my_num == sampler.num_samples
+
+    # did the file get correctly saved?
+    saved_disc = bet.sample.load_discretization(savefile)
+    mdat = bet.sample.loadmat(savefile)
+    print("HERE HERE", mdat, my_num)
+    # comm.barrier()
+    # compare the samples
+    nptest.assert_array_equal(my_discretization.
+                              _input_sample_set.get_values(),
+                              saved_disc._input_sample_set.get_values())
+    # compare the data
+    nptest.assert_array_equal(my_discretization.
+                              _output_sample_set.get_values(),
+                              saved_disc._output_sample_set.get_values())
+
+
+def verify_add_qoi_with_data(model, sampler,
+                             input_sample_set,
+                             savefile):
+    """
+    Verify that the adding data and QoI is done correctly.
+    """
+    # evalulate the model at the samples directly
+    output_values = (np.column_stack([model(input_sample_set._values),
+                                      model(input_sample_set._values)]))
+
+    if len(output_values.shape) == 1:
+        output_sample_set = sample_set(1)
+        prob_set = sample_set(1)
+    else:
+        output_sample_set = sample_set(output_values.shape[1])
+        prob_set = sample_set(output_values.shape[1] // 2)
+
+    output_sample_set.set_values(output_values)
+    discretization = disc(input_sample_set, output_sample_set)
+
+    # evaluate the model at the sample
+    print(savefile, input_sample_set.get_dim())
+    my_discretization = sampler.compute_QoI_and_create_discretization(
+        input_sample_set, savefile, globalize=True)
+
+    # set output_probability_set to not be empty (but with data)
+    my_discretization.set_output_probability_set(prob_set)
+    data_orig = np.random.rand(prob_set.get_dim())
+    my_discretization.set_data(data_orig)
+    data = np.random.rand(prob_set.get_dim())
+    # check add_qoi
+    my_discretization = sampler.add_qoi(my_discretization, data=data,
+                                        savefile=savefile, globalize=True)
+    # comm.barrier()
+
+    my_num = my_discretization.check_nums()
+
+    # compare the samples
+    MD = my_discretization
+    D = discretization
+    nptest.assert_array_equal(MD.get_input().get_values(),
+                              D.get_input().get_values())
+
+    # compare the data
+    nptest.assert_array_equal(MD.get_output().get_values(),
+                              D.get_output().get_values())
+
+    nptest.assert_array_equal(MD.get_data(),
+                              np.concatenate((data_orig, data)))
+
+    # did num_samples get updated?
+    assert my_num == sampler.num_samples
+
+    # did the file get correctly saved?
+    saved_disc = bet.sample.load_discretization(savefile)
+    mdat = bet.sample.loadmat(savefile)
+    print("HERE HERE", mdat, my_num)
+    # comm.barrier()
+    # compare the samples
+    nptest.assert_array_equal(my_discretization.
+                              _input_sample_set.get_values(),
+                              saved_disc._input_sample_set.get_values())
+    # compare the data
+    nptest.assert_array_equal(my_discretization.
+                              _output_sample_set.get_values(),
+                              saved_disc._output_sample_set.get_values())
+
+
+def verify_create_random_discretization(model, sampler,
+                                        sample_type, input_domain,
                                         num_samples, savefile):
 
     np.random.seed(1)
@@ -629,7 +750,7 @@ class Test_basic_sampler(unittest.TestCase):
             self.samplers.append(bsam.sampler(model, num_samples))
 
         self.input_dim1 = 1
-        self.input_dim2 = 2
+        self.input_dim2 = 3  # can be set to other dimensions.
         self.input_dim3 = 10
 
         self.input_sample_set1 = sample_set(self.input_dim1)
@@ -693,7 +814,8 @@ class Test_basic_sampler(unittest.TestCase):
 
         for model, sampler, input_sample_set, savefile in test_list:
             verify_compute_QoI_and_create_discretization(model, sampler,
-                                                         input_sample_set, savefile)
+                                                         input_sample_set,
+                                                         savefile)
 
     def test_random_sample_set(self):
         """
@@ -721,7 +843,8 @@ class Test_basic_sampler(unittest.TestCase):
         for five different input domains.
         """
         input_domain_list = [self.input_domain1, self.input_domain1,
-                             self.input_domain3, self.input_domain3, self.input_domain10]
+                             self.input_domain3, self.input_domain3,
+                             self.input_domain10]
 
         test_list = list(zip(self.samplers, input_domain_list))
 
@@ -799,7 +922,8 @@ class Test_basic_sampler(unittest.TestCase):
         for three different QoI maps (1 to 1, 3 to 1, 3 to 2, 10 to 4).
         """
         input_domain_list = [self.input_domain1, self.input_domain1,
-                             self.input_domain3, self.input_domain3, self.input_domain10]
+                             self.input_domain3, self.input_domain3,
+                             self.input_domain10]
 
         test_list = list(zip(self.models, self.samplers, input_domain_list,
                              self.savefiles))
@@ -808,5 +932,126 @@ class Test_basic_sampler(unittest.TestCase):
             for sample_type in ["random", "r", "lhs"]:
                 for num_samples in [None, 25]:
                     verify_create_random_discretization(model, sampler,
-                                                        sample_type, input_domain, num_samples,
+                                                        sample_type,
+                                                        input_domain,
+                                                        num_samples,
                                                         savefile)
+
+
+class Test_basic_sampler_extended(Test_basic_sampler):
+    """
+    Test model and output appending and reference
+    values for :class:`bet.sampling.basicSampling.sampler`.
+    """
+
+    def setUp(self):
+        # create 1-1 map
+        self.input_domain1 = np.column_stack((np.zeros((1,)), np.ones((1,))))
+
+        def map_1t1(x):
+            return np.sin(x)
+        # create 3-1 map
+        self.input_domain3 = np.column_stack((np.zeros((3,)), np.ones((3,))))
+
+        def map_3t1(x):
+            return np.sum(x, 1)
+
+        # create 3-2 map
+        def map_3t2(x):
+            try:
+                return np.vstack(([x[:, 0] + x[:, 1], x[:, 2]])).transpose()
+            except IndexError:  # support reference-parameter mapping
+                return np.vstack(([x[0] + x[1], x[2]])).transpose()
+        # create 10-4 map
+        self.input_domain10 = np.column_stack(
+            (np.zeros((10,)), np.ones((10,))))
+
+        def map_10t4(x):
+            if len(x.shape) == 1:
+                x = np.array([x])  # support for reference parameter
+            x1 = x[:, 0] + x[:, 1]
+            x2 = x[:, 2] + x[:, 3]
+            x3 = x[:, 4] + x[:, 5]
+            x4 = np.sum(x[:, [6, 7, 8, 9]], 1)
+            return np.vstack([x1, x2, x3, x4]).transpose()
+        num_samples = 100
+        self.savefiles = ["11t11", "1t1", "3to1", "3to2", "10to4"]
+        self.models = [map_1t1, map_1t1, map_3t1, map_3t2, map_10t4]
+        self.samplers = []
+        for model in self.models:
+            self.samplers.append(bsam.sampler(model, num_samples))
+
+        self.input_dim1 = 1
+        self.input_dim2 = 3
+        self.input_dim3 = 10
+
+        self.input_sample_set1 = sample_set(self.input_dim1)
+        ref_val1 = np.random.rand(self.input_dim1)
+        self.input_sample_set1.set_reference_value(ref_val1)
+        self.input_sample_set2 = sample_set(self.input_dim2)
+        ref_val2 = np.random.rand(self.input_dim2)
+        self.input_sample_set2.set_reference_value(ref_val2)
+        self.input_sample_set3 = sample_set(self.input_dim3)
+        ref_val3 = np.random.rand(self.input_dim3)
+        self.input_sample_set3.set_reference_value(ref_val3)
+
+        self.input_sample_set4 = sample_set(self.input_domain1.shape[0])
+        self.input_sample_set4.set_reference_value(ref_val1)
+        self.input_sample_set4.set_domain(self.input_domain1)
+
+        self.input_sample_set5 = sample_set(self.input_domain3.shape[0])
+        self.input_sample_set5.set_reference_value(ref_val2)
+        self.input_sample_set5.set_domain(self.input_domain3)
+
+        self.input_sample_set6 = sample_set(self.input_domain10.shape[0])
+        self.input_sample_set6.set_reference_value(ref_val3)
+        self.input_sample_set6.set_domain(self.input_domain10)
+
+    def test_add_qoi(self):
+        """
+        Test :meth:`bet.sampling.basicSampling.sampler.add_qoi`
+        for three different QoI maps (1 to 1, 3 to 1, 3 to 2, 10 to 4).
+        """
+        # create a list of different sets of samples
+        list_of_samples = [np.ones((4, )), np.ones((4, 1)), np.ones((4, 3)),
+                           np.ones((4, 3)), np.ones((4, 10))]
+        list_of_dims = [1, 1, 3, 3, 10]
+
+        list_of_sample_sets = [None] * len(list_of_samples)
+
+        for i, array in enumerate(list_of_samples):
+            dim = list_of_dims[i]
+            list_of_sample_sets[i] = sample_set(dim)
+            list_of_sample_sets[i].set_values(array)
+            list_of_sample_sets[i].set_reference_value(np.random.rand(dim))
+
+        test_list = list(zip(self.models, self.samplers, list_of_sample_sets,
+                             self.savefiles))
+
+        for model, sampler, input_sample_set, savefile in test_list:
+            verify_add_qoi(model, sampler, input_sample_set, savefile)
+
+    def test_add_qoi_with_data(self):
+        """
+        Test :meth:`bet.sampling.basicSampling.sampler.add_qoi`
+        for three different QoI maps (1 to 1, 3 to 1, 3 to 2, 10 to 4).
+        """
+        # create a list of different sets of samples
+        list_of_samples = [np.ones((4, )), np.ones((4, 1)), np.ones((4, 3)),
+                           np.ones((4, 3)), np.ones((4, 10))]
+        list_of_dims = [1, 1, 3, 3, 10]
+
+        list_of_sample_sets = [None] * len(list_of_samples)
+
+        for i, array in enumerate(list_of_samples):
+            dim = list_of_dims[i]
+            list_of_sample_sets[i] = sample_set(dim)
+            list_of_sample_sets[i].set_values(array)
+            list_of_sample_sets[i].set_reference_value(np.random.rand(dim))
+
+        test_list = list(zip(self.models, self.samplers, list_of_sample_sets,
+                             self.savefiles))
+
+        for model, sampler, input_sample_set, savefile in test_list:
+            verify_add_qoi_with_data(
+                model, sampler, input_sample_set, savefile)


### PR DESCRIPTION
- tested multiple processors
- unlocks scipy
- uses pickling instead of `scipy.io` 
- old `.mat` files aren't quite loaded properly, need to change their extensions to have none (if your scripts coded the saving/loading paths like mine did).
  - this can be addressed with a simple check for file ending when loading. I think there's existing logic to fall back on no extension if `.mat` is not found, but we need to add in the vice-versa logic. if `.mat` is missing, try loading without. should open new issue for it. may not even be a real problem
- some hotfixes I found in comparison module got thrown in as well. sorry they're not separated out. it wasn't anything functional. just efficiency. I noticed that it took too long to compute metrics when loading files, it was because the pointer-loading was mis-coded. tests didn't catch it because the pointers did get built, just took more time. I caught it when expecting blazing fast metric computations on pre-computed pointers for saved files. 
- sample-based methods!
- I've been building up examples in a separate repo, here: https://github.com/mathematicalmichael/thesis/tree/master/examples
  - uses BOTH set and sample-based.
  - command-line modules with documentation, argument parsing
  - model agnostic. swap them out.
  - still work in progress, so data-driven methods examples haven't been included yet
  - that last point is moot for this PR, since these examples focus on comparing set/sample based methods for the same inverse problems, so these show that I've validated (with lots of plotting) the comparisons, caught/fixed bugs as I was running diverse examples, threw fixes right into the `sample` branch that got merged into `develop`
  - that's all to say.. this PR's content has been subject to extensive functional testing

- docstrings still somewhat weak at documenting the arguments, but that's okay for the time being. I'll be adding to them. Really check out the thesis examples, they'll demonstrate usage in the cleanest way.

See https://github.com/mathematicalmichael/BET/pull/30 
Squash merge
--------
* adding TEMPORARY files for CI.

* adding support for more types of kwd args.

* added support for tuple and list.

* linting and io ptr setting.

* resiliency to overwriting observed distribution.

* choose outputs method

* linting.

* whitespace.

* fix tests with sample.

* SET_IO PTR REMOVED FROM PROB

* clean up lines.

* scaffolding for distributions

* Revert "clean up lines."

This reverts commit 4db634773ff61b971af199e3acf623d6e4cb59de.

* Revert "SET_IO PTR REMOVED FROM PROB"

This reverts commit 40a7267c0f994dbf52533017f3e4968ef001216e.

* Revert "Revert "SET_IO PTR REMOVED FROM PROB""

This reverts commit 862f70b87310339027dd5aec97449996d9121a41.

* fixed test.

* Revert "Revert "clean up lines.""

This reverts commit 845e77f3f4ce81857e69b1cdd293993c031ccfa5.

* domain inference and rvs support

* support for kde rvs

* typo.

* self missing

* whitespace.

* ANSATZ CHANGE IN PROB

* hasattr fix.

* typo caused tests to fail.

* pdf and cdf now handle KDE object.

* MC estimate for probabilities.

* TESTS PASS FOR EMULATED PROBS.

* silence the hounds.

* travis simplified down.

* passing tests and several added functions.

* tests passing, WIP

* WIP

* tests passing and whole ton of code added.

* linting

* BUGS FIXED FOR SAMPLING.

* linting.

* minor bugfixes.

* linting.

* bug fixes.

* bug fixes and architecture changes

* scipy version lock.

* sampling tests begun.

* linting.

* manual linting.

* docstrings.

* local overwriting tests now pass.

* WIP. NEEDS REFACTOR.

* TESTS PASSING FINALLY.

* removed redundant method.

* test passing and inverse problem being solved correctly.

* changes so tests pass in higher dimensions!

* no longer does setting the observed overwrite the reference value. must set it explictly.

* tests failing for dimensions both == 1.

* tests now pass in all the dimensions.

* nonrepeated data-driven mode first passing test.

* caught typo.

* tests now passing, likelihood working properly.

* travis file matplotlib re-added for 2.7 to pass, re-aligned setup file for comparison class that is being added to master.

* cover.

* linting.

* scipy import for (still untested) noise-setting.

* resolving some hound-found issues. need more tests for loss function.

* moved line incorrectly.

* linting.

* made std test more robust to sizes.

* removed non-ASCII character from test docs so that tests would pass in python 2.7

* better coverage and tests.

* coverage up to 77

* linting.

* to-do note.

* linting.

* fix bug and more linting.

* fixed failing tests due to typos.

* fixed broken tests and improved coverage ever so slightly.

* repeated tests pass.

* copyright notice.

* addressing some linting issues.

* line overflows.

* info on data driven status from predited.

* linting.

* linting.

* fix unused variables.

* typo.

* fixed typo and some line overflows.

* adding reference value tests.

* autopep linting.

* dimensions fix in basicSampling test.

* WIP

* added successful test for add_data

* fix inheritance tests.

* passing tests for adding data with reference parameter

* passing tests.

* fix typo.

* attempting to fix broken test.

* setup incremented and re-styled to match comparison branch.

* fixed some coverage and deprecation.

* linting.

* fixed behavior of set_data

* linting.

* adding data tests.

* another test for calcP.

* attempt to address coverage in calculateError.

* added methods to aid compatibility with old approach.

* coverage for slicing functions.

* more tests.

* linting.

* attempt to fix broken build.

* likelihood test revision.

* set predicted for likelihood.

* refactor setting data.

* removed test for calculateError

* fixed parallel generation of samples.

* remove pushforward approximation in test.

* revert test.

* serial now loads distribution information.

* distribution loading and saving now works in mat files both in parallel and serial

* refactored set_initial

* linting and cleanup.

* fixed test by using appropriate default value.

* fixed backward incompatible change.

* vim files added to gitignore.

* fixed repeated sampling test to take any length data.

* linting.

* more aggressive linting.

* linting (manually)

* linting (autopep)

* sed replacement for loggin.warn into warning.

* linting after warn.

* full sweep autolinting.

* autolint

* re-added disc.local_to_global. all tests except sample.py pass

* more tests pass but some still fail.

* copy setup.

* overwrite den with None when generating samples.

* accept/reject WIP.

* typo.

* linting.

* travis testing temporarily.

* stylistic changes.

* WIP on parallel pdf.

* adding test file.

* small changes.

* kde tests WIP

* fixed tests.

* autopep linting.

* travis.

* test commit

* linting, comments.

* STABLE. Tests Pass in parallel. needs cleanup.

* reincluded test.

* removed extraneous file added by accident.

* autolinting.

* whitespace.

* line indent.

* whitespacing and typos

* silence the hounds. manual linting.

* manual linting.

* whitespace.

* autopep linting.

* Sample pickle (#31)

* pickling.

* unlocked scipy version once pickle replaced sio.load/savemat

* adding back in passing tests.

* cleanup.

* dont skip test now.

* manual linting.

* manual linting.

* manual linting.

* manual linting.

* drop 2.7 tests.

* try to get travis passing.

* fix some testing bugs.

* found random sampling ignored domain in bsam.

* typo.

* hotfix for compare

* bugfix comparison.

* hotfix.