### PR TITLE
add decorator to skip test in parallel

### DIFF
--- a/test/test_sampling/test_useLUQ.py
+++ b/test/test_sampling/test_useLUQ.py
@@ -27,6 +27,7 @@ except ImportError:
 
 
 @unittest.skipIf(not has_luq, 'LUQ is not installed.')
+@unittest.skipIf(comm.size > 1, 'Only run in serial')
 class Test_useLUQ(unittest.TestCase):
     """
     Testing ``bet.sampling.useLUQ.useLUQ``, interfacing with a model.


### PR DESCRIPTION
useLUQ now only run in serial to avoid errors in parallel testing (fine, because it does not support parallelism)